### PR TITLE
chore: standardize e2e test patterns

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -50,9 +50,7 @@ export default defineConfig({
     },
   ],
 
-  reporter: process.env.CI
-    ? [["html", { outputFolder: "playwright-report" }]]
-    : [["list"], ["html"]],
+  reporter: process.env.CI ? [["html", { open: "never" }]] : [["list"], ["html"]],
   retries: process.env.CI ? 2 : 0,
   testDir: "./tests/e2e",
 

--- a/tests/e2e/fixtures/auth.fixture.ts
+++ b/tests/e2e/fixtures/auth.fixture.ts
@@ -12,7 +12,7 @@ type Fixtures = {
   registerPage: RegisterPage;
 };
 
-export const test = base.extend<Fixtures>({
+const test = base.extend<Fixtures>({
   dashboardPage: async ({ page }, use) => {
     await use(new DashboardPage(page));
   },
@@ -27,4 +27,5 @@ export const test = base.extend<Fixtures>({
   },
 });
 
+export { test };
 export { expect } from "@playwright/test";


### PR DESCRIPTION
## Summary
- Fixture export style: `export const test` → `export { test }` for consistency with other repos
- CI reporter: `html` with `open: "never"` (matches collabtime, frow, localcine)

## Test plan
- [ ] E2E tests still pass
- [ ] Lint/format clean