### PR TITLE
test: add unit tests for core business logic

### DIFF
--- a/apps/api/src/middleware/error-handler.test.ts
+++ b/apps/api/src/middleware/error-handler.test.ts
@@ -1,0 +1,183 @@
+import type { Context } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { describe, expect, it, vi } from "vitest";
+import { ZodError } from "zod";
+
+vi.mock("@/lib/env", () => ({
+  env: { NODE_ENV: "development" },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn() },
+}));
+
+import { env } from "@/lib/env";
+
+import { AppError, errorHandler, notFound } from "./error-handler";
+
+const createMockContext = (headers: Record<string, string> = {}) => {
+  return {
+    json: vi.fn((body: unknown, status?: number) => ({ body, status })),
+    req: {
+      header: vi.fn((name: string) => headers[name]),
+      method: "GET",
+      url: "http://localhost/test",
+    },
+  } as unknown as Context & { json: ReturnType<typeof vi.fn> };
+};
+
+describe("AppError", () => {
+  it("should use default statusCode 500 and isOperational true", () => {
+    const error = new AppError("Something broke");
+    expect(error.message).toBe("Something broke");
+    expect(error.statusCode).toBe(500);
+    expect(error.isOperational).toBe(true);
+    expect(error.code).toBeUndefined();
+  });
+
+  it("should accept custom statusCode and isOperational", () => {
+    const error = new AppError("Not found", 404, false);
+    expect(error.statusCode).toBe(404);
+    expect(error.isOperational).toBe(false);
+  });
+
+  it("should accept optional error code", () => {
+    const error = new AppError("Bad", 400, true, "VALIDATION_FAILED");
+    expect(error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("should have a stack trace", () => {
+    const error = new AppError("Test");
+    expect(error.stack).toBeDefined();
+  });
+});
+
+describe("errorHandler", () => {
+  it("should handle HTTPException", async () => {
+    const c = createMockContext();
+    const err = new HTTPException(403, { message: "Forbidden" });
+
+    await errorHandler(err, c);
+
+    expect(c.json).toHaveBeenCalledWith(
+      { error: { code: "HTTP_EXCEPTION", message: "Forbidden" } },
+      403,
+    );
+  });
+
+  it("should handle ZodError with field details", async () => {
+    const c = createMockContext();
+    const err = new ZodError([
+      {
+        code: "too_small",
+        inclusive: true,
+        message: "Required",
+        minimum: 1,
+        path: ["name"],
+        type: "string",
+      },
+    ]);
+
+    await errorHandler(err, c);
+
+    expect(c.json).toHaveBeenCalledWith(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          details: [{ field: "name", message: "Required" }],
+          message: "Validation failed",
+        },
+      },
+      400,
+    );
+  });
+
+  it("should handle AppError with custom code", async () => {
+    const c = createMockContext();
+    const err = new AppError("User not found", 404, true, "USER_NOT_FOUND");
+
+    await errorHandler(err, c);
+
+    expect(c.json).toHaveBeenCalledWith(
+      { error: { code: "USER_NOT_FOUND", message: "User not found" } },
+      404,
+    );
+  });
+
+  it("should handle AppError without code defaulting to APP_ERROR", async () => {
+    const c = createMockContext();
+    const err = new AppError("Something wrong", 422);
+
+    await errorHandler(err, c);
+
+    expect(c.json).toHaveBeenCalledWith(
+      { error: { code: "APP_ERROR", message: "Something wrong" } },
+      422,
+    );
+  });
+
+  it("should handle P2002 as 409 DUPLICATE_ENTRY", async () => {
+    const c = createMockContext();
+    const err = new Error("Unique constraint failed P2002");
+
+    await errorHandler(err, c);
+
+    expect(c.json).toHaveBeenCalledWith(
+      { error: { code: "DUPLICATE_ENTRY", message: "A record with this value already exists" } },
+      409,
+    );
+  });
+
+  it("should handle P2025 as 404 NOT_FOUND", async () => {
+    const c = createMockContext();
+    const err = new Error("Record not found P2025");
+
+    await errorHandler(err, c);
+
+    expect(c.json).toHaveBeenCalledWith(
+      { error: { code: "NOT_FOUND", message: "Record not found" } },
+      404,
+    );
+  });
+
+  it("should include error message and stack in development", async () => {
+    const c = createMockContext();
+    const err = new Error("dev error");
+
+    await errorHandler(err, c);
+
+    const call = c.json.mock.calls[0];
+    expect(call?.[0]?.error?.message).toBe("dev error");
+    expect(call?.[0]?.error?.stack).toBeDefined();
+    expect(call?.[1]).toBe(500);
+  });
+
+  it("should hide error message in production", async () => {
+    const mutableEnv = env as { NODE_ENV: string };
+    mutableEnv.NODE_ENV = "production";
+
+    const c = createMockContext();
+    const err = new Error("secret detail");
+
+    await errorHandler(err, c);
+
+    const call = c.json.mock.calls[0];
+    expect(call?.[0]?.error?.message).toBe("An unexpected error occurred");
+    expect(call?.[0]?.error?.stack).toBeUndefined();
+
+    mutableEnv.NODE_ENV = "development";
+  });
+});
+
+describe("notFound", () => {
+  it("should return 404 with NOT_FOUND code", () => {
+    const c = createMockContext();
+
+    notFound(c);
+
+    expect(c.json).toHaveBeenCalledWith(
+      { error: { code: "NOT_FOUND", message: "Resource not found" } },
+      404,
+    );
+  });
+});

--- a/apps/api/src/middleware/security.test.ts
+++ b/apps/api/src/middleware/security.test.ts
@@ -1,0 +1,117 @@
+import type { Context } from "hono";
+import { describe, expect, it, vi } from "vitest";
+
+import { requestId, requestSizeLimit } from "./security";
+
+const createMockContext = (options: { headers?: Record<string, string> } = {}) => {
+  const { headers = {} } = options;
+  const variables = new Map<string, unknown>();
+
+  return {
+    get: vi.fn((key: string) => variables.get(key)),
+    header: vi.fn(),
+    json: vi.fn((body: unknown, status?: number) => ({ body, status })),
+    req: {
+      header: vi.fn((name: string) => headers[name]),
+      method: "GET",
+      path: "/test",
+      url: "http://localhost/test",
+    },
+    set: vi.fn((key: string, value: unknown) => {
+      variables.set(key, value);
+    }),
+  } as unknown as Context & { json: ReturnType<typeof vi.fn> };
+};
+
+describe("requestSizeLimit", () => {
+  const next = vi.fn();
+
+  it("should reject requests exceeding max size", async () => {
+    const middleware = requestSizeLimit(1024);
+    const c = createMockContext({ headers: { "content-length": "2048" } });
+
+    await middleware(c, next);
+
+    expect(c.json).toHaveBeenCalledWith(
+      { error: { code: "PAYLOAD_TOO_LARGE", message: "Request entity too large" } },
+      413,
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("should pass requests within size limit", async () => {
+    const middleware = requestSizeLimit(1024);
+    const c = createMockContext({ headers: { "content-length": "512" } });
+
+    await middleware(c, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("should pass requests with no content-length header", async () => {
+    const middleware = requestSizeLimit(1024);
+    const c = createMockContext();
+
+    await middleware(c, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("should use default 10MB limit when no argument provided", async () => {
+    const middleware = requestSizeLimit();
+    const c = createMockContext({ headers: { "content-length": "5000000" } });
+
+    await middleware(c, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("should reject when exceeding default 10MB limit", async () => {
+    const middleware = requestSizeLimit();
+    const c = createMockContext({ headers: { "content-length": "20000000" } });
+
+    await middleware(c, next);
+
+    expect(c.json).toHaveBeenCalledWith(
+      { error: { code: "PAYLOAD_TOO_LARGE", message: "Request entity too large" } },
+      413,
+    );
+  });
+});
+
+describe("requestId", () => {
+  const next = vi.fn();
+
+  it("should use existing x-request-id header", async () => {
+    const c = createMockContext({ headers: { "x-request-id": "existing-id" } });
+
+    await requestId(c, next);
+
+    expect(c.set).toHaveBeenCalledWith("requestId", "existing-id");
+    expect(c.header).toHaveBeenCalledWith("x-request-id", "existing-id");
+  });
+
+  it("should generate UUID when no x-request-id header", async () => {
+    const mockUuid = "generated-uuid-1234";
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      mockUuid as `${string}-${string}-${string}-${string}-${string}`,
+    );
+
+    const c = createMockContext();
+
+    await requestId(c, next);
+
+    expect(c.set).toHaveBeenCalledWith("requestId", mockUuid);
+    expect(c.header).toHaveBeenCalledWith("x-request-id", mockUuid);
+
+    vi.restoreAllMocks();
+  });
+
+  it("should call next", async () => {
+    const c = createMockContext({ headers: { "x-request-id": "test" } });
+
+    await requestId(c, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/user.service.test.ts
+++ b/apps/api/src/services/user.service.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@repo/db", () => ({
+  prisma: {
+    user: {
+      count: vi.fn(),
+      delete: vi.fn(),
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/env", () => ({
+  env: { NODE_ENV: "test" },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn() },
+}));
+
+import { prisma } from "@repo/db";
+
+import { AppError } from "@/middleware/error-handler";
+
+import { UserService } from "./user.service";
+
+const userService = new UserService();
+
+const mockUser = {
+  createdAt: new Date("2024-01-01"),
+  displayName: "Test User",
+  email: "test@example.com",
+  emailVerified: true,
+  id: "user-1",
+  name: "Test",
+  updatedAt: new Date("2024-01-01"),
+  username: "testuser",
+};
+
+describe("UserService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("findById", () => {
+    it("should return user when found", async () => {
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as never);
+
+      const result = await userService.findById("user-1");
+
+      expect(result).toEqual(mockUser);
+      expect(prisma.user.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "user-1" } }),
+      );
+    });
+
+    it("should throw AppError 404 when user not found", async () => {
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(null as never);
+
+      await expect(userService.findById("missing")).rejects.toThrow(AppError);
+      await expect(userService.findById("missing")).rejects.toMatchObject({
+        code: "USER_NOT_FOUND",
+        statusCode: 404,
+      });
+    });
+
+    it("should throw AppError 500 on database error", async () => {
+      vi.mocked(prisma.user.findUnique).mockRejectedValue(new Error("DB connection lost"));
+
+      await expect(userService.findById("user-1")).rejects.toThrow(AppError);
+      await expect(userService.findById("user-1")).rejects.toMatchObject({
+        code: "USER_FETCH_ERROR",
+        statusCode: 500,
+      });
+    });
+  });
+
+  describe("findByEmail", () => {
+    it("should return user when found", async () => {
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as never);
+
+      const result = await userService.findByEmail("test@example.com");
+
+      expect(result).toEqual(mockUser);
+    });
+
+    it("should return null when user not found", async () => {
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(null as never);
+
+      const result = await userService.findByEmail("missing@example.com");
+
+      expect(result).toBeNull();
+    });
+
+    it("should throw AppError 500 on database error", async () => {
+      vi.mocked(prisma.user.findUnique).mockRejectedValue(new Error("DB error"));
+
+      await expect(userService.findByEmail("test@example.com")).rejects.toMatchObject({
+        code: "USER_FETCH_ERROR",
+        statusCode: 500,
+      });
+    });
+  });
+
+  describe("update", () => {
+    it("should update and return user", async () => {
+      vi.mocked(prisma.user.findFirst).mockResolvedValue(null as never);
+      vi.mocked(prisma.user.update).mockResolvedValue(mockUser as never);
+
+      const result = await userService.update("user-1", { name: "New Name" });
+
+      expect(result).toEqual(mockUser);
+    });
+
+    it("should throw AppError 400 when username is taken", async () => {
+      vi.mocked(prisma.user.findFirst).mockResolvedValue(mockUser as never);
+
+      await expect(userService.update("user-2", { username: "testuser" })).rejects.toMatchObject({
+        code: "USERNAME_TAKEN",
+        statusCode: 400,
+      });
+    });
+
+    it("should skip username check when username is not provided", async () => {
+      vi.mocked(prisma.user.update).mockResolvedValue(mockUser as never);
+
+      await userService.update("user-1", { name: "Updated" });
+
+      expect(prisma.user.findFirst).not.toHaveBeenCalled();
+    });
+
+    it("should throw AppError 404 on P2025 error", async () => {
+      vi.mocked(prisma.user.findFirst).mockResolvedValue(null as never);
+      vi.mocked(prisma.user.update).mockRejectedValue(new Error("Record not found P2025"));
+
+      await expect(userService.update("missing", { name: "X" })).rejects.toMatchObject({
+        code: "USER_NOT_FOUND",
+        statusCode: 404,
+      });
+    });
+
+    it("should throw AppError 500 on generic database error", async () => {
+      vi.mocked(prisma.user.findFirst).mockResolvedValue(null as never);
+      vi.mocked(prisma.user.update).mockRejectedValue(new Error("Connection refused"));
+
+      await expect(userService.update("user-1", { name: "X" })).rejects.toMatchObject({
+        code: "USER_UPDATE_ERROR",
+        statusCode: 500,
+      });
+    });
+  });
+
+  describe("delete", () => {
+    it("should delete user and return success", async () => {
+      vi.mocked(prisma.user.delete).mockResolvedValue(mockUser as never);
+
+      const result = await userService.delete("user-1");
+
+      expect(result).toEqual({ success: true });
+      expect(prisma.user.delete).toHaveBeenCalledWith({ where: { id: "user-1" } });
+    });
+
+    it("should throw AppError 404 on P2025 error", async () => {
+      vi.mocked(prisma.user.delete).mockRejectedValue(new Error("Record not found P2025"));
+
+      await expect(userService.delete("missing")).rejects.toMatchObject({
+        code: "USER_NOT_FOUND",
+        statusCode: 404,
+      });
+    });
+
+    it("should throw AppError 500 on generic database error", async () => {
+      vi.mocked(prisma.user.delete).mockRejectedValue(new Error("DB error"));
+
+      await expect(userService.delete("user-1")).rejects.toMatchObject({
+        code: "USER_DELETE_ERROR",
+        statusCode: 500,
+      });
+    });
+  });
+
+  describe("list", () => {
+    it("should return users with pagination metadata", async () => {
+      vi.mocked(prisma.user.findMany).mockResolvedValue([mockUser] as never);
+      vi.mocked(prisma.user.count).mockResolvedValue(25 as never);
+
+      const result = await userService.list({ skip: 10, take: 10 });
+
+      expect(result.data).toEqual([mockUser]);
+      expect(result.meta).toEqual({ skip: 10, take: 10, total: 25 });
+    });
+
+    it("should default skip to 0 and take to users length", async () => {
+      vi.mocked(prisma.user.findMany).mockResolvedValue([mockUser] as never);
+      vi.mocked(prisma.user.count).mockResolvedValue(1 as never);
+
+      const result = await userService.list({});
+
+      expect(result.meta).toEqual({ skip: 0, take: 1, total: 1 });
+    });
+
+    it("should throw AppError 500 on database error", async () => {
+      vi.mocked(prisma.user.findMany).mockRejectedValue(new Error("DB error"));
+
+      await expect(userService.list({})).rejects.toMatchObject({
+        code: "USER_LIST_ERROR",
+        statusCode: 500,
+      });
+    });
+  });
+});

--- a/packages/auth/src/server.test.ts
+++ b/packages/auth/src/server.test.ts
@@ -1,8 +1,8 @@
 import { prisma } from "@repo/db";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { createAuth } from "../server";
-import type { AuthConfig } from "../server";
+import { createAuth } from "./server";
+import type { AuthConfig } from "./server";
 
 type Plugin = NonNullable<AuthConfig["extraPlugins"]>[number];
 
@@ -131,5 +131,34 @@ describe("Auth Server Configuration", () => {
     });
     const plugins = extendedAuth.options.plugins ?? [];
     expect(plugins.some((p) => p.id === "test-plugin")).toBe(true);
+  });
+
+  it("should not configure verification email when resendApiKey is absent", () => {
+    expect(auth.options.emailVerification?.sendVerificationEmail).toBeUndefined();
+  });
+
+  it("should configure verification email when resendApiKey is provided", () => {
+    const emailAuth = createAuth({
+      prisma,
+      resendApiKey: "re_test_key",
+      secret: "test-secret-minimum-32-characters-long",
+    });
+    expect(emailAuth.options.emailVerification?.sendVerificationEmail).toBeDefined();
+  });
+
+  it("should disable rate limiting when CI is true", () => {
+    vi.stubEnv("CI", "true");
+
+    const ciAuth = createAuth({ prisma, secret: "test-secret-minimum-32-characters-long" });
+    expect(ciAuth.options.rateLimit?.enabled).toBe(false);
+  });
+
+  it("should have displayName as optional additional user field", () => {
+    const displayName = auth.options.user?.additionalFields?.displayName;
+    expect(displayName).toEqual({
+      defaultValue: null,
+      required: false,
+      type: "string",
+    });
   });
 });

--- a/packages/ui/src/hooks/use-toast.test.ts
+++ b/packages/ui/src/hooks/use-toast.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { reducer } from "./use-toast";
+
+const makeToast = (id: string, open = true) =>
+  ({ id, open, title: `Toast ${id}` }) as Parameters<typeof reducer>[0]["toasts"][number];
+
+describe("reducer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should add a toast with ADD_TOAST", () => {
+    const state = { toasts: [] };
+    const toast = makeToast("1");
+
+    const result = reducer(state, { toast, type: "ADD_TOAST" });
+
+    expect(result.toasts).toHaveLength(1);
+    expect(result.toasts[0]?.id).toBe("1");
+  });
+
+  it("should limit toasts to 1", () => {
+    const state = { toasts: [makeToast("1")] };
+    const toast = makeToast("2");
+
+    const result = reducer(state, { toast, type: "ADD_TOAST" });
+
+    expect(result.toasts).toHaveLength(1);
+    expect(result.toasts[0]?.id).toBe("2");
+  });
+
+  it("should update a matching toast with UPDATE_TOAST", () => {
+    const state = { toasts: [makeToast("1")] };
+
+    const result = reducer(state, {
+      toast: { id: "1", title: "Updated" },
+      type: "UPDATE_TOAST",
+    });
+
+    expect(result.toasts[0]?.title).toBe("Updated");
+  });
+
+  it("should not update non-matching toasts", () => {
+    const state = { toasts: [makeToast("1")] };
+
+    const result = reducer(state, {
+      toast: { id: "99", title: "Nope" },
+      type: "UPDATE_TOAST",
+    });
+
+    expect(result.toasts[0]?.title).toBe("Toast 1");
+  });
+
+  it("should set open to false on DISMISS_TOAST with specific id", () => {
+    const state = { toasts: [makeToast("1")] };
+
+    const result = reducer(state, { toastId: "1", type: "DISMISS_TOAST" });
+
+    expect(result.toasts[0]?.open).toBe(false);
+  });
+
+  it("should set open to false on all toasts when DISMISS_TOAST has no id", () => {
+    const state = { toasts: [makeToast("1")] };
+
+    const result = reducer(state, { toastId: undefined, type: "DISMISS_TOAST" });
+
+    expect(result.toasts[0]?.open).toBe(false);
+  });
+
+  it("should remove specific toast with REMOVE_TOAST", () => {
+    const state = { toasts: [makeToast("1")] };
+
+    const result = reducer(state, { toastId: "1", type: "REMOVE_TOAST" });
+
+    expect(result.toasts).toHaveLength(0);
+  });
+
+  it("should remove all toasts when REMOVE_TOAST has no id", () => {
+    const state = { toasts: [makeToast("1")] };
+
+    const result = reducer(state, { toastId: undefined, type: "REMOVE_TOAST" });
+
+    expect(result.toasts).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/lib/utils.test.ts
+++ b/packages/ui/src/lib/utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { cn } from "./utils";
+
+describe("cn", () => {
+  it("should merge multiple class names", () => {
+    expect(cn("foo", "bar")).toBe("foo bar");
+  });
+
+  it("should handle conditional classes", () => {
+    const condition = false;
+    expect(cn("foo", condition && "bar", "baz")).toBe("foo baz");
+  });
+
+  it("should resolve tailwind conflicts by keeping the last one", () => {
+    expect(cn("p-4", "p-2")).toBe("p-2");
+  });
+
+  it("should handle ui: prefixed classes", () => {
+    // ui: variant classes coexist with non-prefixed (different variant scope)
+    expect(cn("ui:p-4", "p-2")).toBe("ui:p-4 p-2");
+    // ui: prefixed classes conflict with each other
+    expect(cn("ui:p-4", "ui:p-2")).toBe("ui:p-2");
+  });
+
+  it("should return empty string for no inputs", () => {
+    expect(cn()).toBe("");
+  });
+
+  it("should handle array inputs", () => {
+    expect(cn(["foo", "bar"])).toBe("foo bar");
+  });
+
+  it("should handle object inputs", () => {
+    expect(cn({ bar: false, foo: true })).toBe("foo");
+  });
+
+  it("should handle mixed inputs", () => {
+    expect(cn("foo", ["bar"], { baz: true })).toBe("foo bar baz");
+  });
+});


### PR DESCRIPTION
## Summary
- Add co-located unit tests for error handler (AppError, errorHandler, notFound), user service (all CRUD methods with error paths), security middleware (requestSizeLimit, requestId), UI utils (cn with tailwind merge), and toast reducer (all action types)
- Extend auth server tests with 4 missing cases: email verification config, CI rate limiting, and displayName field
- Move existing auth test from `__tests__/` directory to co-located pattern, matching conventions across collabtime, localcine, and frow monorepos

## Test plan
- [x] `pnpm --filter @repo/ui test` passes (16 tests)
- [x] `pnpm --filter @repo/auth test` passes (25 tests)
- [x] `pnpm --filter api test` passes (38 tests)
- [x] `pnpm run test` full suite passes (8 tasks, all green)