### PR TITLE
perf: hoist date to module scope + add Suspense fallback

### DIFF
--- a/apps/landing/src/components/footer.tsx
+++ b/apps/landing/src/components/footer.tsx
@@ -1,10 +1,12 @@
 import Link from "next/link";
 
+const YEAR = new Date().getFullYear();
+
 const Footer = () => {
   return (
     <footer className="border-t border-border">
       <div className="mx-auto flex max-w-(--breakpoint-xl) flex-col gap-6 px-6 py-10 text-sm text-muted-foreground md:flex-row md:items-center md:justify-between md:px-8">
-        <p>&copy; {new Date().getFullYear()} Acme. All rights reserved.</p>
+        <p>&copy; {YEAR} Acme. All rights reserved.</p>
         <nav className="flex flex-wrap items-center gap-6 font-normal">
           <Link className="transition-colors hover:text-foreground" href="/privacy">
             Privacy

--- a/apps/web/src/app/(auth)/register/page.tsx
+++ b/apps/web/src/app/(auth)/register/page.tsx
@@ -5,6 +5,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@repo/ui/components/card";
+import { Skeleton } from "@repo/ui/components/skeleton";
 import { Metadata } from "next";
 import { Suspense } from "react";
 
@@ -22,7 +23,7 @@ const Page = async () => {
         <CardDescription>Enter your details below to create your account</CardDescription>
       </CardHeader>
       <CardContent>
-        <Suspense>
+        <Suspense fallback={<Skeleton className="h-64 w-full" />}>
           <RegisterForm />
         </Suspense>
       </CardContent>


### PR DESCRIPTION
Low-effort React best-practices sweep from a repo audit against Vercel's React guidelines.

## Changes

- **`apps/landing/src/components/footer.tsx`** — `new Date().getFullYear()` was being re-evaluated on every render. Hoisted to module scope since it's computed once per server render anyway.
- **`apps/web/src/app/(auth)/register/page.tsx`** — bare `<Suspense>` with no `fallback` was rendering nothing while `RegisterForm` loaded. Added a skeleton so the card doesn't flash empty.

## Test plan
- [x] `pnpm build`
- [ ] Manual: verify register page shows a skeleton during the form's streaming fetch