### PR TITLE
fix(web): make auth form links visually distinguishable

### DIFF
--- a/apps/web/src/app/(auth)/login/form.tsx
+++ b/apps/web/src/app/(auth)/login/form.tsx
@@ -105,7 +105,7 @@ const LoginForm = ({ from }: Props) => {
                 <div className="flex items-center">
                   <FieldLabel htmlFor="password">Password</FieldLabel>
                   <Link
-                    className="ml-auto text-sm underline-offset-4 hover:underline"
+                    className="ml-auto text-sm text-foreground underline underline-offset-4"
                     href="/recover"
                   >
                     Forgot your password?
@@ -134,7 +134,10 @@ const LoginForm = ({ from }: Props) => {
             {isLoading ? "Signing in..." : "Sign in"}
           </Button>
           <FieldDescription className="text-center">
-            Don&apos;t have an account? <Link href="/register">Sign up</Link>
+            Don&apos;t have an account?{" "}
+            <Link className="text-foreground underline underline-offset-4" href="/register">
+              Sign up
+            </Link>
           </FieldDescription>
         </Field>
       </FieldGroup>

--- a/apps/web/src/app/(auth)/recover/form.tsx
+++ b/apps/web/src/app/(auth)/recover/form.tsx
@@ -98,7 +98,10 @@ const RecoverForm = () => {
             {isLoading ? "Sending..." : "Send reset link"}
           </Button>
           <FieldDescription className="text-center">
-            Remembered your password? <Link href="/login">Sign in</Link>
+            Remembered your password?{" "}
+            <Link className="text-foreground underline underline-offset-4" href="/login">
+              Sign in
+            </Link>
           </FieldDescription>
         </Field>
       </FieldGroup>

--- a/apps/web/src/app/(auth)/register/form.tsx
+++ b/apps/web/src/app/(auth)/register/form.tsx
@@ -176,7 +176,10 @@ const RegisterForm = () => {
             {isLoading ? "Creating account..." : "Create account"}
           </Button>
           <FieldDescription className="text-center">
-            Already have an account? <Link href="/login">Sign in</Link>
+            Already have an account?{" "}
+            <Link className="text-foreground underline underline-offset-4" href="/login">
+              Sign in
+            </Link>
           </FieldDescription>
         </Field>
       </FieldGroup>

--- a/apps/web/src/app/(auth)/reset-password/form.tsx
+++ b/apps/web/src/app/(auth)/reset-password/form.tsx
@@ -136,7 +136,10 @@ const ResetPasswordForm = ({ token }: Props) => {
             {isLoading ? "Resetting..." : "Reset password"}
           </Button>
           <FieldDescription className="text-center">
-            Back to <Link href="/login">sign in</Link>
+            Back to{" "}
+            <Link className="text-foreground underline underline-offset-4" href="/login">
+              sign in
+            </Link>
           </FieldDescription>
         </Field>
       </FieldGroup>


### PR DESCRIPTION
## Summary
- Add `text-foreground underline underline-offset-4` to all `<Link>` elements inside `FieldDescription` on login, register, recover, and reset-password forms so they stand out from surrounding muted text.
- Update the "Forgot your password?" link on the login form to always show its underline and use `text-foreground`, replacing the previous hover-only underline.

## Test plan
- [ ] Visit each auth page (login, register, recover, reset-password) and verify links are visually distinct from muted text
- [ ] Verify links work correctly when clicked
- [ ] Check both light and dark themes