### PR TITLE
refactor: React best-practices sweep

### DIFF
--- a/apps/web/src/app/(auth)/register/page.tsx
+++ b/apps/web/src/app/(auth)/register/page.tsx
@@ -5,9 +5,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@repo/ui/components/card";
-import { Skeleton } from "@repo/ui/components/skeleton";
 import { Metadata } from "next";
-import { Suspense } from "react";
 
 import RegisterForm from "@/app/(auth)/register/form";
 
@@ -15,7 +13,7 @@ const metadata: Metadata = {
   title: "Create an account - Acme",
 };
 
-const Page = async () => {
+const Page = () => {
   return (
     <Card>
       <CardHeader className="text-center">
@@ -23,9 +21,7 @@ const Page = async () => {
         <CardDescription>Enter your details below to create your account</CardDescription>
       </CardHeader>
       <CardContent>
-        <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-          <RegisterForm />
-        </Suspense>
+        <RegisterForm />
       </CardContent>
     </Card>
   );

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 
-const Layout = async ({ children }: { children: ReactNode }) => {
+const Layout = ({ children }: { children: ReactNode }) => {
   return <div>{children}</div>;
 };
 

--- a/packages/ui/src/hooks/use-toast.ts
+++ b/packages/ui/src/hooks/use-toast.ts
@@ -166,6 +166,9 @@ function toast({ ...props }: Toast) {
 function useToast() {
   const [state, setState] = useState<State>(memoryState);
 
+  // Subscribe once on mount; setState is stable, and re-subscribing on every
+  // state change would tear down + reattach the listener for no reason
+  // (and could miss dispatches in between).
   useEffect(() => {
     listeners.push(setState);
     return () => {
@@ -174,7 +177,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,


### PR DESCRIPTION
## Summary

Audited `apps/**/src` and `packages/ui/src` against the Vercel React Best Practices guide (rules 1.x waterfalls, 5.x re-render/effects) and the React docs on `useEffect`. The acme template is small and already clean — most categories had nothing to fix (no inline component definitions, no barrel-imported heavy deps, no missing `dynamic()` for tiptap/leaflet/charts because those libs aren't used, `getSession` already wrapped in `React.cache`, list service already uses `Promise.all`).

Three real issues found and fixed.

## Fixes

**Effects (rule 5.7 — narrow effect dependencies):**
- `packages/ui/src/hooks/use-toast.ts:169` — `useEffect` listed `state` in its deps. Since the effect only push/pops a stable `setState` from the listeners array, depending on `state` caused the listener to be torn down and reattached on every dispatch (and opened a tiny window where in-flight dispatches could miss the listener). Changed deps to `[]`.

**Server Components / Suspense (rules 1.5, 3.6):**
- `apps/web/src/app/(dashboard)/layout.tsx:3` — `async` layout that awaits nothing. Dropped `async`.
- `apps/web/src/app/(auth)/register/page.tsx:18` — `async` page that awaits nothing, plus a `<Suspense fallback={<Skeleton/>}>` wrapping `<RegisterForm />`. The form is a `"use client"` component with no async work; the boundary never suspends, so the skeleton is dead UI. Removed both. Side effect from the build: `/register` now prerenders as `○` (static) instead of `ƒ` (dynamic).

## Deliberately skipped

- `apps/landing/src/components/analytics.tsx` uses `dynamic(..., { ssr: false })` inside a `"use client"` module. Redundant but functional — leaving it to avoid behavior change.
- No `useMemo`/`useCallback`/`React.memo` added — none of the existing components had a measurable re-render chain that warrants them.
- Nothing under `apps/api` (Hono) — out of scope for React/Next best practices; data layer already uses `Promise.all`.

## Pattern candidates for standards.md

- Rule against `async` on Server Components / layouts that await nothing — they pessimize Next's static analysis (the `/register` build output proves it).
- Rule against `<Suspense>` boundaries wrapping client components that don't suspend — they add a fallback that never renders and create cargo-culted dead UI.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build` (note `/register` flipped from `ƒ` → `○`)
- [x] `pnpm format:check`