### PR TITLE
feat: add 404 pages to web and landing apps

### DIFF
--- a/apps/landing/src/app/not-found.tsx
+++ b/apps/landing/src/app/not-found.tsx
@@ -1,0 +1,22 @@
+import { Button } from "@repo/ui/components/button";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Page not found",
+};
+
+const NotFound = () => (
+  <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-6 text-center">
+    <p className="text-8xl font-bold tracking-tight text-foreground">404</p>
+    <div className="flex flex-col gap-2">
+      <h1 className="text-2xl font-semibold text-foreground">Page not found</h1>
+      <p className="max-w-md text-sm text-muted-foreground">
+        The page you&rsquo;re looking for doesn&rsquo;t exist or has been moved.
+      </p>
+    </div>
+    <Button render={<Link href="/" />}>Go home</Button>
+  </main>
+);
+
+export default NotFound;

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,22 @@
+import { Button } from "@repo/ui/components/button";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Page not found",
+};
+
+const NotFound = () => (
+  <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-6 text-center">
+    <p className="text-8xl font-bold tracking-tight text-foreground">404</p>
+    <div className="flex flex-col gap-2">
+      <h1 className="text-2xl font-semibold text-foreground">Page not found</h1>
+      <p className="max-w-md text-sm text-muted-foreground">
+        The page you&rsquo;re looking for doesn&rsquo;t exist or has been moved.
+      </p>
+    </div>
+    <Button render={<Link href="/" />}>Go home</Button>
+  </main>
+);
+
+export default NotFound;


### PR DESCRIPTION
## Summary
- Adds `not-found.tsx` to `apps/web` and `apps/landing` (the two Next.js apps in the monorepo).
- Uses `@repo/ui` `Button` with `render={<Link href=\"/\" />}` pattern and semantic theme tokens only (`bg-background`, `text-foreground`, `text-muted-foreground`).
- Sets `metadata.title = \"Page not found\"` so the layout's title template produces `Page not found | Acme`.

## Per-app status
- `apps/web` — created
- `apps/landing` — created
- `apps/api` — skipped (no `next` dep)
- `apps/workshop` — skipped (no `next` dep)

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm format:check` passes
- [x] `pnpm build` passes (both apps emit `/_not-found` route)