### PR TITLE
refactor(ui): adopt React 19 ref prop + use() in field and skeleton

### DIFF
--- a/packages/ui/src/components/field.tsx
+++ b/packages/ui/src/components/field.tsx
@@ -1,62 +1,49 @@
 "use client";
 
-import { type ComponentProps, createContext, forwardRef, useContext, useId } from "react";
+import { type ComponentProps, createContext, use, useId } from "react";
 
 import { cn } from "../lib/utils";
 
 type FieldContextValue = { id: string };
 const FieldContext = createContext<FieldContextValue>({ id: "" });
-const useFieldContext = () => useContext(FieldContext);
+const useFieldContext = () => use(FieldContext);
 
-const Field = forwardRef<HTMLDivElement, ComponentProps<"div">>(({ className, ...props }, ref) => {
+const Field = ({ className, ...props }: ComponentProps<"div">) => {
   const id = useId();
   return (
-    <FieldContext.Provider value={{ id }}>
-      <div ref={ref} className={cn("flex flex-col gap-2", className)} {...props} />
-    </FieldContext.Provider>
+    <FieldContext value={{ id }}>
+      <div className={cn("flex flex-col gap-2", className)} {...props} />
+    </FieldContext>
   );
-});
-Field.displayName = "Field";
+};
 
-const FieldGroup = forwardRef<HTMLDivElement, ComponentProps<"div">>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex flex-col gap-4", className)} {...props} />
-  ),
+const FieldGroup = ({ className, ...props }: ComponentProps<"div">) => (
+  <div className={cn("flex flex-col gap-4", className)} {...props} />
 );
-FieldGroup.displayName = "FieldGroup";
 
-const FieldLabel = forwardRef<HTMLLabelElement, ComponentProps<"label">>(
-  ({ className, ...props }, ref) => (
-    <label
-      ref={ref}
-      className={cn(
-        "text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
-        className,
-      )}
-      {...props}
-    />
-  ),
+const FieldLabel = ({ className, ...props }: ComponentProps<"label">) => (
+  <label
+    className={cn(
+      "text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className,
+    )}
+    {...props}
+  />
 );
-FieldLabel.displayName = "FieldLabel";
 
-const FieldContent = forwardRef<HTMLDivElement, ComponentProps<"div">>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex flex-col gap-1", className)} {...props} />
-  ),
+const FieldContent = ({ className, ...props }: ComponentProps<"div">) => (
+  <div className={cn("flex flex-col gap-1", className)} {...props} />
 );
-FieldContent.displayName = "FieldContent";
 
-const FieldDescription = forwardRef<HTMLParagraphElement, ComponentProps<"p">>(
-  ({ className, ...props }, ref) => (
-    <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
-  ),
+const FieldDescription = ({ className, ...props }: ComponentProps<"p">) => (
+  <p className={cn("text-sm text-muted-foreground", className)} {...props} />
 );
-FieldDescription.displayName = "FieldDescription";
 
-const FieldError = forwardRef<
-  HTMLParagraphElement,
-  ComponentProps<"p"> & { errors?: Array<unknown> }
->(({ className, errors, ...props }, ref) => {
+const FieldError = ({
+  className,
+  errors,
+  ...props
+}: ComponentProps<"p"> & { errors?: Array<unknown> }) => {
   if (!errors || errors.length === 0) {
     return null;
   }
@@ -73,12 +60,11 @@ const FieldError = forwardRef<
     return null;
   }
   return (
-    <p ref={ref} className={cn("text-sm font-medium text-destructive", className)} {...props}>
+    <p className={cn("text-sm font-medium text-destructive", className)} {...props}>
       {messages.join(", ")}
     </p>
   );
-});
-FieldError.displayName = "FieldError";
+};
 
 export {
   Field,

--- a/packages/ui/src/components/skeleton.tsx
+++ b/packages/ui/src/components/skeleton.tsx
@@ -1,5 +1,4 @@
 import type { HTMLAttributes } from "react";
-import { forwardRef } from "react";
 
 import { cn } from "../lib/utils";
 
@@ -14,38 +13,41 @@ type SkeletonAvatarProps = SkeletonProps & {
   size?: number;
 };
 
-const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
-  ({ animation = "pulse", className, height, style, variant = "text", width, ...props }, ref) => {
-    const variantClasses = {
-      circular: "rounded-full",
-      rectangular: "rounded-none",
-      rounded: "rounded-lg",
-      text: "rounded-md",
-    };
+const Skeleton = ({
+  animation = "pulse",
+  className,
+  height,
+  style,
+  variant = "text",
+  width,
+  ...props
+}: SkeletonProps) => {
+  const variantClasses = {
+    circular: "rounded-full",
+    rectangular: "rounded-none",
+    rounded: "rounded-lg",
+    text: "rounded-md",
+  };
 
-    const animationClasses = {
-      none: "",
-      pulse: "animate-pulse",
-      wave: "animate-shimmer",
-    };
+  const animationClasses = {
+    none: "",
+    pulse: "animate-pulse",
+    wave: "animate-shimmer",
+  };
 
-    return (
-      <div
-        aria-hidden="true"
-        className={cn("bg-muted", variantClasses[variant], animationClasses[animation], className)}
-        ref={ref}
-        style={{
-          height: height || "1.2em",
-          width: width || "100%",
-          ...style,
-        }}
-        {...props}
-      />
-    );
-  },
-);
-
-Skeleton.displayName = "Skeleton";
+  return (
+    <div
+      aria-hidden="true"
+      className={cn("bg-muted", variantClasses[variant], animationClasses[animation], className)}
+      style={{
+        height: height || "1.2em",
+        width: width || "100%",
+        ...style,
+      }}
+      {...props}
+    />
+  );
+};
 
 // Skeleton container for grouping multiple skeletons
 type SkeletonContainerProps = HTMLAttributes<HTMLDivElement> & {
@@ -53,65 +55,52 @@ type SkeletonContainerProps = HTMLAttributes<HTMLDivElement> & {
   spacing?: "sm" | "md" | "lg";
 };
 
-const SkeletonContainer = forwardRef<HTMLDivElement, SkeletonContainerProps>(
-  ({ children, className, count = 1, spacing = "md", ...props }, ref) => {
-    const spacingClasses = {
-      lg: "space-y-4",
-      md: "space-y-3",
-      sm: "space-y-2",
-    };
+const SkeletonContainer = ({
+  children,
+  className,
+  count = 1,
+  spacing = "md",
+  ...props
+}: SkeletonContainerProps) => {
+  const spacingClasses = {
+    lg: "space-y-4",
+    md: "space-y-3",
+    sm: "space-y-2",
+  };
 
-    if (count > 1 && !children) {
-      return (
-        <div className={cn(spacingClasses[spacing], className)} ref={ref} {...props}>
-          {Array.from({ length: count }).map((_, i) => (
-            <Skeleton key={i} />
-          ))}
-        </div>
-      );
-    }
-
+  if (count > 1 && !children) {
     return (
-      <div className={cn(spacingClasses[spacing], className)} ref={ref} {...props}>
-        {children}
+      <div className={cn(spacingClasses[spacing], className)} {...props}>
+        {Array.from({ length: count }).map((_, i) => (
+          <Skeleton key={i} />
+        ))}
       </div>
     );
-  },
-);
+  }
 
-SkeletonContainer.displayName = "SkeletonContainer";
+  return (
+    <div className={cn(spacingClasses[spacing], className)} {...props}>
+      {children}
+    </div>
+  );
+};
 
 // Pre-built skeleton patterns
-const SkeletonCard = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
-    return (
-      <div className={cn("space-y-3 rounded-lg border p-4", className)} ref={ref} {...props}>
-        <Skeleton className="mb-4" height={200} variant="rectangular" />
-        <Skeleton variant="text" width="60%" />
-        <Skeleton variant="text" width="80%" />
-        <Skeleton variant="text" width="40%" />
-      </div>
-    );
-  },
-);
+const SkeletonCard = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => {
+  return (
+    <div className={cn("space-y-3 rounded-lg border p-4", className)} {...props}>
+      <Skeleton className="mb-4" height={200} variant="rectangular" />
+      <Skeleton variant="text" width="60%" />
+      <Skeleton variant="text" width="80%" />
+      <Skeleton variant="text" width="40%" />
+    </div>
+  );
+};
 
-SkeletonCard.displayName = "SkeletonCard";
-
-const SkeletonAvatar = forwardRef<HTMLDivElement, SkeletonAvatarProps>(
-  ({ className, size = 40, ...props }, ref) => {
-    return (
-      <Skeleton
-        className={className}
-        height={size}
-        ref={ref}
-        variant="circular"
-        width={size}
-        {...props}
-      />
-    );
-  },
-);
-
-SkeletonAvatar.displayName = "SkeletonAvatar";
+const SkeletonAvatar = ({ className, size = 40, ...props }: SkeletonAvatarProps) => {
+  return (
+    <Skeleton className={className} height={size} variant="circular" width={size} {...props} />
+  );
+};
 
 export { Skeleton, SkeletonContainer, SkeletonCard, SkeletonAvatar };


### PR DESCRIPTION
## Summary

Modernizes two UI components to React 19 idioms. Pure structural refactor — no behavior change, no public API change.

### Changes

**`packages/ui/src/components/field.tsx`**
- Drops `forwardRef` on 6 subcomponents (`Field`, `FieldGroup`, `FieldLabel`, `FieldContent`, `FieldDescription`, `FieldError`). In React 19, `ref` is a regular prop on host elements — wrappers spread `...props` onto a single `<div>`/`<label>`/`<p>`, so refs still flow through naturally.
- `useContext(FieldContext)` → `use(FieldContext)` in `useFieldContext`.
- `<FieldContext.Provider value={...}>` → `<FieldContext value={...}>` (React 19 treats context objects as providers directly).
- Removes the now-unneeded `displayName` assignments.

**`packages/ui/src/components/skeleton.tsx`**
- Drops `forwardRef` on `Skeleton`, `SkeletonContainer`, `SkeletonCard`, `SkeletonAvatar`. Same rationale — refs pass through via `{...props}`.
- Removes `displayName` assignments.

### Why these two and nothing else

Audited `apps/**/src` and `packages/ui/src` against the composition-patterns skill. Rejected:

- `button.tsx`, `card.tsx`, `toast.tsx` — already clean (compound, CVA variants, no `forwardRef`).
- `input.tsx` — `startIcon`/`endIcon` are `ReactElement` props, not booleans; current API reads fine.
- App components (`landing/components/*`, `web/components/*`) — too small to have composition problems.
- No boolean-prop proliferation (3+ toggles), no render props, no mode-forking variants anywhere in the repo.

The remaining signal was the React 19 modernization — `forwardRef` and `useContext` were the only live rule violations.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm format:check`
- [ ] Manual: auth forms (`login`, `register`, `recover`, `reset-password`) render correctly — they consume `Field` but do not pass `ref`.