### PR TITLE
chore: canonicalize root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 node_modules
 .pnp
 .pnp.js
+.pnpm-store
 
 # testing
 coverage
@@ -16,6 +17,17 @@ test-results/
 .next/
 out/
 build
+next-env.d.ts
+
+# build
+dist/
+*.tsbuildinfo
+
+# turbo
+.turbo
+
+# vercel
+.vercel
 
 # misc
 .DS_Store
@@ -25,30 +37,27 @@ build
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*
+!.env.example
 
-# turbo
-.turbo
+# IDE
+.idea
+.vscode
+*.swp
+*.swo
 
-# vercel
-.vercel
+# logs
+logs/
+*.log
 
-# build
-dist/
+# prisma generated
+**/src/generated/
 
 # redis
 *.rdb
 
-# prisma generated client
-packages/db/src/generated
-
-# counselors agent output
+# agent output
 agents/
-# typescript build info
-*.tsbuildinfo


### PR DESCRIPTION
## Summary

Establishes the canonical root `.gitignore` for acme (the template repo). This is a best-of-breed merge of what currently exists across the four managed repos (acme, localcine, collabtime, frow). Sibling repos will sync to match this baseline.

## Consolidations

- **Env files**: collapse `.env`, `.env.local`, `.env.development.local`, `.env.test.local`, `.env.production.local` into `.env*` with `!.env.example`. Any new env variant gets ignored automatically; checked-in `.env.example` files stay tracked.
- **Prisma generated output**: broaden `packages/db/src/generated` to `**/src/generated/` so generated client paths are covered regardless of which package they land in.
- **Added**: `.pnpm-store`, `next-env.d.ts`, `*.tsbuildinfo` (unified under build), `.pnpm-debug.log*`, IDE entries (`.idea`, `.vscode`, `*.swp`, `*.swo`), log entries (`logs/`, `*.log`).
- **Renamed comment**: `counselors agent output` to `agent output` (generic).
- **Reorganized**: grouped related sections (build, turbo, vercel near each other) for readability.

## Verification

- `git status --ignored` — no surprises, already-tracked files (`next-env.d.ts` in `apps/landing` and `apps/web`, `.env.example` files) remain tracked.
- `pnpm typecheck` — pass
- `pnpm lint` — pass
- `pnpm build` — pass
- `pnpm format:check` — pass

## Test plan

- [ ] CI green
- [ ] Sibling repos (localcine, collabtime, frow) opened as follow-up PRs syncing to this file