### PR TITLE
chore: allow worktree subdomains in dev origins

### DIFF
--- a/apps/landing/next.config.ts
+++ b/apps/landing/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  allowedDevOrigins: ["acme.landing.localhost", "*.acme.landing.localhost"],
+  allowedDevOrigins: ["acme.landing.localhost", "*.acme.landing.localhost", "*.vercel.app"],
   reactStrictMode: true,
   transpilePackages: ["@repo/ui"],
 };

--- a/apps/landing/next.config.ts
+++ b/apps/landing/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  allowedDevOrigins: ["acme.landing.localhost"],
+  allowedDevOrigins: ["acme.landing.localhost", "*.acme.landing.localhost"],
   reactStrictMode: true,
   transpilePackages: ["@repo/ui"],
 };

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,7 +3,7 @@ import type { NextConfig } from "next";
 const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
 
 const nextConfig: NextConfig = {
-  allowedDevOrigins: ["acme.web.localhost", "*.acme.web.localhost"],
+  allowedDevOrigins: ["acme.web.localhost", "*.acme.web.localhost", "*.vercel.app"],
   reactStrictMode: true,
 
   async rewrites() {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,7 +3,7 @@ import type { NextConfig } from "next";
 const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
 
 const nextConfig: NextConfig = {
-  allowedDevOrigins: ["acme.web.localhost"],
+  allowedDevOrigins: ["acme.web.localhost", "*.acme.web.localhost"],
   reactStrictMode: true,
 
   async rewrites() {


### PR DESCRIPTION
## Summary

Adds `*.acme.web.localhost` and `*.acme.landing.localhost` wildcards to `allowedDevOrigins` in both Next.js apps so the dev-server origin check accepts requests from branch worktree subdomains.

## Why

Per orchestrator `standards.md` § Dev Environment, branch worktrees are served at `http://<branch>.<project>.<app>.localhost:1355`. Without the wildcard, Next rejects requests from those subdomains and font preloading, Server Actions, and HMR fail. The orchestrator `verify-dev.sh` check expects every managed repo to include the worktree wildcard.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm format:check`
- [ ] Verify a worktree subdomain (`http://feat-x.acme.web.localhost:1355`) no longer triggers Next's cross-origin warning in dev