### PR TITLE
chore: drop oxlint overrides, bump awesomeness 3.0.1

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U test -d test"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -52,6 +52,8 @@ const metadata = {
   },
 } satisfies Metadata;
 
+// next/font/google fonts are factory calls (`Inter({...})`), not constructors
+// oxlint-disable-next-line new-cap
 const inter = Inter({
   subsets: ["latin"],
   variable: "--font-sans",

--- a/apps/landing/src/components/analytics.tsx
+++ b/apps/landing/src/components/analytics.tsx
@@ -3,7 +3,10 @@
 import dynamic from "next/dynamic";
 
 const Analytics = dynamic(
-  () => import("@vercel/analytics/react").then((mod) => ({ default: mod.Analytics })),
+  async () => {
+    const mod = await import("@vercel/analytics/react");
+    return { default: mod.Analytics };
+  },
   { ssr: false },
 );
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,8 @@ import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 import type { ReactNode } from "react";
 
+// next/font/google fonts are factory calls (`Inter({...})`), not constructors
+// oxlint-disable-next-line new-cap
 const inter = Inter({
   display: "swap", // Improve font loading performance
   subsets: ["latin"],

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -3,28 +3,4 @@ import awesomeness from "oxlint-config-awesomeness";
 
 export default defineConfig({
   extends: [awesomeness],
-  overrides: [
-    {
-      files: ["apps/**/src/app/**/layout.tsx"],
-      rules: {
-        // next/font/google fonts are factory calls (`Inter({...})`), not constructors
-        "new-cap": "off",
-      },
-    },
-    {
-      files: ["apps/**/src/components/analytics.tsx"],
-      rules: {
-        // next/dynamic requires .then() to remap a named export onto `default`
-        "promise/prefer-await-to-then": "off",
-      },
-    },
-    {
-      // Design system variants (size, intent, etc.) order semantically, not alphabetically
-      files: ["packages/ui/src/**"],
-      rules: {
-        "perfectionist/sort-jsx-props": "off",
-        "perfectionist/sort-objects": "off",
-      },
-    },
-  ],
 });

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint-staged": "^16.4.0",
     "oxfmt": "^0.45.0",
     "oxlint": "^1.60.0",
-    "oxlint-config-awesomeness": "^3.0.0",
+    "oxlint-config-awesomeness": "^3.0.1",
     "turbo": "^2.9.6"
   },
   "lint-staged": {

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,3 +1,6 @@
+// CVA variants (variant, size) order semantically, not alphabetically
+// oxlint-disable perfectionist/sort-objects
+// oxlint-disable perfectionist/sort-jsx-props
 import { Button as ButtonPrimitive } from "@base-ui/react/button";
 import { cva, type VariantProps } from "class-variance-authority";
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -66,29 +66,28 @@ export default defineConfig({
 
   // CI spawns three webServers in parallel. Wrapping each in `pnpm --filter`
   // serializes them on pnpm's workspace state lock — the first wins, the
-  // rest hang silently for the full timeout. Run the binaries directly with
-  // an explicit cwd so each spawn is independent.
+  // rest hang silently for the full timeout. Run the binaries directly so
+  // each spawn is independent. Pnpm hoists shared bins to the repo-root
+  // `node_modules/.bin/`, so we reference them from there and pass the app
+  // directory as an arg to `next start`.
   webServer: process.env.CI
     ? [
         {
-          command: "./node_modules/.bin/next start --port 3000",
-          cwd: "apps/web",
+          command: "node_modules/.bin/next start apps/web --port 3000",
           stderr: "pipe",
           stdout: "pipe",
           timeout: 120_000,
           url: webUrl,
         },
         {
-          command: "node dist/index.mjs",
-          cwd: "apps/api",
+          command: "node apps/api/dist/index.mjs",
           stderr: "pipe",
           stdout: "pipe",
           timeout: 120_000,
           url: `${apiUrl}/healthz`,
         },
         {
-          command: "./node_modules/.bin/next start --port 3001",
-          cwd: "apps/landing",
+          command: "node_modules/.bin/next start apps/landing --port 3001",
           stderr: "pipe",
           stdout: "pipe",
           timeout: 120_000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,9 +16,12 @@ const getPortlessUrl = (name: string) => {
   }
 };
 
-export const webUrl = getPortlessUrl("acme.web") ?? "http://localhost:3000";
-export const apiUrl = getPortlessUrl("acme.api") ?? "http://localhost:4000";
-export const landingUrl = getPortlessUrl("acme.landing") ?? "http://localhost:3001";
+// CI servers bind to 0.0.0.0 (IPv4) but Node 18+ resolves `localhost` to ::1
+// first via getaddrinfo, and undici/fetch doesn't fall back to IPv4. Use the
+// explicit IPv4 loopback for CI probes; locally portless gives us the real URL.
+export const webUrl = getPortlessUrl("acme.web") ?? "http://127.0.0.1:3000";
+export const apiUrl = getPortlessUrl("acme.api") ?? "http://127.0.0.1:4000";
+export const landingUrl = getPortlessUrl("acme.landing") ?? "http://127.0.0.1:3001";
 
 export default defineConfig({
   forbidOnly: !!process.env.CI,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -64,24 +64,31 @@ export default defineConfig({
     video: "retain-on-failure",
   },
 
+  // CI spawns three webServers in parallel. Wrapping each in `pnpm --filter`
+  // serializes them on pnpm's workspace state lock — the first wins, the
+  // rest hang silently for the full timeout. Run the binaries directly with
+  // an explicit cwd so each spawn is independent.
   webServer: process.env.CI
     ? [
         {
-          command: "pnpm --filter web exec next start --port 3000",
+          command: "./node_modules/.bin/next start --port 3000",
+          cwd: "apps/web",
           stderr: "pipe",
           stdout: "pipe",
           timeout: 120_000,
           url: webUrl,
         },
         {
-          command: "pnpm --filter api run start",
+          command: "node dist/index.mjs",
+          cwd: "apps/api",
           stderr: "pipe",
           stdout: "pipe",
           timeout: 120_000,
           url: `${apiUrl}/healthz`,
         },
         {
-          command: "pnpm --filter landing exec next start --port 3001",
+          command: "./node_modules/.bin/next start --port 3001",
+          cwd: "apps/landing",
           stderr: "pipe",
           stdout: "pipe",
           timeout: 120_000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^1.60.0
         version: 1.60.0
       oxlint-config-awesomeness:
-        specifier: ^3.0.0
-        version: 3.0.0(eslint@9.39.2(jiti@2.6.1))(oxlint@1.60.0)(typescript@6.0.2)
+        specifier: ^3.0.1
+        version: 3.0.1(eslint@9.39.2(jiti@2.6.1))(oxlint@1.60.0)(typescript@6.0.2)
       turbo:
         specifier: ^2.9.6
         version: 2.9.6
@@ -165,7 +165,7 @@ importers:
         version: 1.29.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       better-auth:
         specifier: ^1.6.2
-        version: 1.6.2(fdf6dd2d7373a9888e96bd9ace6eb18c)
+        version: 1.6.2(364df2851abe4e9973450a08ce7e3cab)
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.5)
@@ -226,7 +226,7 @@ importers:
         version: link:../db
       better-auth:
         specifier: ^1.6.2
-        version: 1.6.2(fdf6dd2d7373a9888e96bd9ace6eb18c)
+        version: 1.6.2(364df2851abe4e9973450a08ce7e3cab)
       resend:
         specifier: ^6.11.0
         version: 6.11.0
@@ -4398,8 +4398,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  oxlint-config-awesomeness@3.0.0:
-    resolution: {integrity: sha512-0wScDboV5XHxbvLx7dcSU00ZBdVtcQpQvD8l0daekggUgpahdSCD13CggBd1EhtCoMh/RFckQ3doyECA8JZXUg==}
+  oxlint-config-awesomeness@3.0.1:
+    resolution: {integrity: sha512-BQttWLrAp37aMmmvQbmaP0P9g0vTwbVhGxi91T5GWAi8t233667yM8FsWgAGhndO9wwIdiNnS88XDYolIiwGxA==}
     hasBin: true
     peerDependencies:
       oxlint: '>=1.58.0 <2.0.0'
@@ -7341,7 +7341,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.18: {}
 
-  better-auth@1.6.2(fdf6dd2d7373a9888e96bd9ace6eb18c):
+  better-auth@1.6.2(364df2851abe4e9973450a08ce7e3cab):
     dependencies:
       '@better-auth/core': 1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.1(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(typescript@6.0.2))(@types/pg@8.20.0)(kysely@0.28.16)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.2)))
@@ -8773,7 +8773,7 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.45.0
       '@oxfmt/binding-win32-x64-msvc': 0.45.0
 
-  oxlint-config-awesomeness@3.0.0(eslint@9.39.2(jiti@2.6.1))(oxlint@1.60.0)(typescript@6.0.2):
+  oxlint-config-awesomeness@3.0.1(eslint@9.39.2(jiti@2.6.1))(oxlint@1.60.0)(typescript@6.0.2):
     dependencies:
       eslint-plugin-no-only-tests: 3.3.0
       eslint-plugin-perfectionist: 5.8.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)


### PR DESCRIPTION
## Summary

- Bump `oxlint-config-awesomeness` from `^3.0.0` to `^3.0.1`.
- Drop the entire `overrides` array from `oxlint.config.ts`. The file is now just `defineConfig({ extends: [awesomeness] })`.
- Replace the three blanket file-pattern overrides with precise, justified disables at each actual violation site.

## Rationale

Blanket `overrides` in the lint config silently widen exceptions across whole directories and hide the framework/design-system reasons for each carve-out. Pulling each exception down to the source file (with a one-line WHY comment) keeps the rule on by default for new code and surfaces the constraint where it lives.

## Changes per former override

- `apps/**/src/app/**/layout.tsx` — `new-cap: off`
  - Replaced with `// oxlint-disable-next-line new-cap` on the `Inter({...})` call in `apps/landing/src/app/layout.tsx` and `apps/web/src/app/layout.tsx`. Comment explains: next/font/google fonts are factory calls, not constructors.

- `apps/**/src/components/analytics.tsx` — `promise/prefer-await-to-then: off`
  - Refactored. `dynamic(() => import(...).then(mod => ({ default: mod.Analytics })))` became `dynamic(async () => { const mod = await import(...); return { default: mod.Analytics }; })`. No disable needed.

- `packages/ui/src/**` — `perfectionist/sort-jsx-props: off` + `perfectionist/sort-objects: off`
  - The only file in `packages/ui/src` that violated either rule was `button.tsx` (CVA variants/sizes ordered semantically). Added file-scoped `// oxlint-disable perfectionist/sort-objects` and `// oxlint-disable perfectionist/sort-jsx-props` at the top with a one-line WHY. The rules stay on for every other file in `@repo/ui`, including new ones.

## Test plan

- [x] `pnpm lint` clean across all 7 packages
- [x] `pnpm typecheck` clean
- [x] `pnpm test` clean (151 tests across 5 packages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed custom lint rule overrides and updated lint configuration for simpler defaults.
  * Upgraded a dev dependency for lint tooling.
  * Added targeted lint suppressions/comments in layout and UI components to reduce noisy warnings.
  * Refactored an analytics dynamic loader for clarity (no runtime behavior change).
  * Adjusted CI/test config and E2E startup/healthcheck commands for more explicit process control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->