### PR TITLE
test(e2e): cover the reset-password flow

### DIFF
--- a/tests/e2e/auth/reset-password.spec.ts
+++ b/tests/e2e/auth/reset-password.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "../fixtures/auth.fixture";
+
+test.describe("Reset Password", () => {
+  test("renders the reset password form", async ({ page, resetPasswordPage }) => {
+    await page.context().clearCookies();
+
+    await resetPasswordPage.goto("any-token-value");
+
+    await resetPasswordPage.expectHeadingVisible();
+  });
+
+  test("shows error when submitted without a token", async ({ page, resetPasswordPage }) => {
+    await page.context().clearCookies();
+
+    await resetPasswordPage.goto();
+    await resetPasswordPage.submit("NewPassword123!", "NewPassword123!");
+
+    await resetPasswordPage.expectErrorText(/invalid reset token/i);
+    expect(page.url()).toContain("/reset-password");
+  });
+
+  test("shows error when passwords do not match", async ({ page, resetPasswordPage }) => {
+    await page.context().clearCookies();
+
+    await resetPasswordPage.goto("any-token-value");
+    await resetPasswordPage.submit("NewPassword123!", "DifferentPassword1!");
+
+    await resetPasswordPage.expectErrorText(/passwords do not match/i);
+    expect(page.url()).toContain("/reset-password");
+  });
+
+  test("shows validation error for short password", async ({ page, resetPasswordPage }) => {
+    await page.context().clearCookies();
+
+    await resetPasswordPage.goto("any-token-value");
+    await resetPasswordPage.submit("short", "short");
+
+    await expect(page.getByText(/at least 12 characters/i).first()).toBeVisible();
+    expect(page.url()).toContain("/reset-password");
+  });
+
+  test("rejects an invalid token at the auth server", async ({ page, resetPasswordPage }) => {
+    await page.context().clearCookies();
+
+    await resetPasswordPage.goto("definitely-not-a-real-token");
+    await resetPasswordPage.submit("ValidPassword123!", "ValidPassword123!");
+
+    // Better Auth rejects unknown tokens — the form surfaces the server message
+    // (varies by version, but always renders into the destructive root error).
+    await expect(page.locator("p.text-destructive")).toBeVisible();
+    expect(page.url()).toContain("/reset-password");
+  });
+});

--- a/tests/e2e/fixtures/auth.fixture.ts
+++ b/tests/e2e/fixtures/auth.fixture.ts
@@ -4,12 +4,14 @@ import { DashboardPage } from "../pages/dashboard.page";
 import { LoginPage } from "../pages/login.page";
 import { RecoverPage } from "../pages/recover.page";
 import { RegisterPage } from "../pages/register.page";
+import { ResetPasswordPage } from "../pages/reset-password.page";
 
 type Fixtures = {
   dashboardPage: DashboardPage;
   loginPage: LoginPage;
   recoverPage: RecoverPage;
   registerPage: RegisterPage;
+  resetPasswordPage: ResetPasswordPage;
 };
 
 const test = base.extend<Fixtures>({
@@ -24,6 +26,9 @@ const test = base.extend<Fixtures>({
   },
   registerPage: async ({ page }, use) => {
     await use(new RegisterPage(page));
+  },
+  resetPasswordPage: async ({ page }, use) => {
+    await use(new ResetPasswordPage(page));
   },
 });
 

--- a/tests/e2e/pages/reset-password.page.ts
+++ b/tests/e2e/pages/reset-password.page.ts
@@ -1,0 +1,39 @@
+import { expect } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
+
+export class ResetPasswordPage {
+  private readonly heading: Locator;
+  private readonly passwordInput: Locator;
+  private readonly confirmPasswordInput: Locator;
+  private readonly submitButton: Locator;
+  private readonly rootError: Locator;
+
+  constructor(private readonly page: Page) {
+    // CardTitle renders as <div>, not a semantic heading — match by text.
+    this.heading = page.getByText("Reset your password", { exact: true });
+    this.passwordInput = page.getByLabel("New password", { exact: true });
+    this.confirmPasswordInput = page.getByLabel(/confirm password/i);
+    this.submitButton = page.getByRole("button", { name: /reset password/i });
+    // Root errors render via a <p class="text-sm text-destructive"> sibling.
+    this.rootError = page.locator("p.text-destructive");
+  }
+
+  goto = async (token?: string) => {
+    const path = token ? `/reset-password?token=${encodeURIComponent(token)}` : "/reset-password";
+    await this.page.goto(path);
+  };
+
+  submit = async (password: string, confirmPassword: string) => {
+    await this.passwordInput.fill(password);
+    await this.confirmPasswordInput.fill(confirmPassword);
+    await this.submitButton.click();
+  };
+
+  expectHeadingVisible = async () => {
+    await expect(this.heading).toBeVisible();
+  };
+
+  expectErrorText = async (text: string | RegExp) => {
+    await expect(this.rootError).toContainText(text);
+  };
+}


### PR DESCRIPTION
## Summary

Closes a gap identified in the recent e2e coverage audit: recovery was only tested at the request-form layer, not the actual reset-password page.

- Adds 5 tests covering form render, missing token, password mismatch, short password, invalid-token rejection by the auth server
- New page object `tests/e2e/pages/reset-password.page.ts` follows the existing pattern (no raw `.click()`/`.fill()` in spec body)
- Wires the page object into `tests/e2e/fixtures/auth.fixture.ts` for fixture injection

Other audit findings (cross-app cookie scope, API auth, profile UI) were either already covered by existing specs or aren't gaps (no profile UI exists).

## Test plan

- [ ] \`pnpm exec playwright test tests/e2e/auth/reset-password.spec.ts --project=chromium\` passes locally
- [ ] CI: green on chromium / firefox / webkit

## Notes

Surfaced 3 pre-existing local-only flakes during the audit (in \`auth/login.spec.ts\` — tests that don't \`clearCookies()\` first fail when storageState is already authed). Not addressed here per "don't modify existing specs" — worth a separate cleanup PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test coverage for the password reset flow, including validation scenarios for missing tokens, password mismatch, minimum length requirements, and authentication errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->