### PR TITLE
fix(auth): notify existing user + show verification UI on signup

### DIFF
--- a/apps/web/src/app/(auth)/register/form.tsx
+++ b/apps/web/src/app/(auth)/register/form.tsx
@@ -31,6 +31,7 @@ const RegisterForm = () => {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const [rootError, setRootError] = useState<string | null>(null);
+  const [pendingVerificationEmail, setPendingVerificationEmail] = useState<string | null>(null);
 
   const form = useForm({
     defaultValues,
@@ -55,6 +56,18 @@ const RegisterForm = () => {
           return;
         }
 
+        // requireEmailVerification gates auto-sign-in: when active, Better Auth
+        // returns the user but no session token. The dashboard middleware would
+        // bounce the user back to /login (looking like silent failure), so show
+        // a verification UI instead. The wording stays ambiguous so it's also
+        // correct for the enumeration-prevention path (existing email →
+        // synthetic-success). The real account holder gets a separate
+        // notification email via emailAndPassword.onExistingUserSignUp.
+        if (!result.data?.token) {
+          setPendingVerificationEmail(value.email);
+          return;
+        }
+
         router.push("/dashboard");
         router.refresh();
       } catch {
@@ -67,6 +80,29 @@ const RegisterForm = () => {
       onSubmit: registerSchema,
     },
   });
+
+  if (pendingVerificationEmail) {
+    return (
+      <div className="flex flex-col items-center gap-2 text-center">
+        <p className="font-semibold">Check your email</p>
+        <p className="text-sm text-muted-foreground">
+          If <span className="font-medium text-foreground">{pendingVerificationEmail}</span> is new
+          to acme, we&apos;ve sent a verification link — click it to activate your account.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Already have an account?{" "}
+          <Link className="text-foreground underline underline-offset-4" href="/login">
+            Sign in
+          </Link>{" "}
+          or{" "}
+          <Link className="text-foreground underline underline-offset-4" href="/recover">
+            reset your password
+          </Link>
+          .
+        </p>
+      </div>
+    );
+  }
 
   return (
     <form

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -98,6 +98,34 @@ export const createAuth = (config: AuthConfig) => {
       enabled: true,
       maxPasswordLength: 128,
       minPasswordLength: 12,
+      // requireEmailVerification activates Better Auth's enumeration-prevention
+      // path — signing up with an already-registered email returns a synthetic
+      // success response. onExistingUserSignUp below notifies the real account
+      // holder so they're not left waiting for a verification email that won't
+      // arrive. See better-auth docs "Email Enumeration Protection".
+      onExistingUserSignUp: resendApiKey
+        ? async ({ user }, request) => {
+            // Derive the web origin from the signup request (CORS already
+            // validated it via trustedOrigins) so the email links back to the
+            // app the user actually came from.
+            const origin = request?.headers.get("origin") ?? "";
+            const { Resend } = await import("resend");
+            const resend = new Resend(resendApiKey);
+            const { error } = await resend.emails.send({
+              from: fromEmail,
+              html: `<p>Someone tried to create a new acme account using your email address (${user.email}). If this was you, <a href="${origin}/login">sign in</a> or <a href="${origin}/recover">reset your password</a> instead. If not, you can safely ignore this email — no account changes were made.</p>`,
+              subject: "Sign-up attempt with your acme account",
+              to: user.email,
+            });
+            if (error) {
+              // Don't throw — Better Auth's enumeration-prevention path needs
+              // to return success regardless. Log so delivery failures don't
+              // break the auth response.
+              // eslint-disable-next-line no-console -- temporary until a structured logger lands
+              console.error("[Auth] Failed to send sign-up attempt email:", error);
+            }
+          }
+        : undefined,
       // Gate on Resend availability rather than NODE_ENV. If no API key is
       // configured we physically can't send a verification email — requiring
       // verification under that condition would lock all new users out


### PR DESCRIPTION
## Summary

User-reported: signup fails silently when the email is already registered (and previously: also for legitimate new signups in production where verification is required).

Root cause: Better Auth's enumeration-prevention path activates when \`requireEmailVerification: true\` (which it is in production with Resend configured). Per the [docs](https://www.better-auth.com/docs/authentication/email-password#email-enumeration-protection):

> When \`requireEmailVerification\` is enabled, signing up with an existing email returns a success response instead of an error to prevent user enumeration.

The previous form did \`router.push(\"/dashboard\")\` regardless, then the dashboard middleware bounced the user to /login with no message — looked like silent failure.

## Changes

**Server** — \`packages/auth/src/server.ts\`
- Adds \`emailAndPassword.onExistingUserSignUp\` (the documented escape hatch) — sends the real account holder a \"sign-up attempt with your acme account\" email containing sign-in + password-reset links
- Web origin is derived from the request's \`Origin\` header (already CORS-validated via \`trustedOrigins\`) so the email links back to the right app
- Resend errors are logged, not thrown — Better Auth's enumeration contract requires the response to look identical regardless of email outcome

**Client** — \`apps/web/src/app/(auth)/register/form.tsx\`
- After successful signup, gates on \`result.data?.token\`: if absent (verification required OR enumeration-prevention), shows a \"Check your email\" UI
- Wording stays ambiguous (\"if X is new to acme, we've sent a link\") so users with pre-existing accounts see the same screen + get sign-in/recover CTAs
- Real new users hit the same UI and get the actual verification email

## Test plan

- [ ] Sign up with a new email (with Resend configured) → see \"Check your email\" UI → verification email arrives
- [ ] Sign up with an existing-registered email → see the same UI → \"Sign in\" / \"Reset password\" links work; the existing account holder receives the sign-up-attempt notification
- [ ] Sign up in dev/CI without Resend (\`requireEmailVerification: false\`) → still pushes to /dashboard as before
- [ ] \`pnpm exec playwright test tests/e2e/auth/register.spec.ts --project=chromium\` — existing tests still green
- [x] \`pnpm --filter web typecheck\` — clean
- [x] \`pnpm --filter @repo/auth lint\` + \`pnpm --filter web lint\` — clean

## Related

- Supersedes #49 (which was comment-only)
- Frow has the matching fix: https://github.com/unlockers-io/frow-monorepo/pull/139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registration now displays an email verification prompt with "Check your email" messaging when verification is required, including options to sign in or reset password.
  * Sign-up attempts with existing email addresses now trigger a notification email to the user, containing login and password recovery links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->