### PR TITLE
fix(e2e): unblock acme e2e (probe URL + 127.0.0.1 trustedOrigins)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,8 +17,12 @@ jobs:
       CI: true
       DATABASE_URL: postgresql://test:test@localhost:5432/test
       BETTER_AUTH_SECRET: test-secret-minimum-32-characters-long-for-e2e
-      BETTER_AUTH_URL: http://localhost:3000
-      NEXT_PUBLIC_API_URL: http://localhost:4000
+      # Use 127.0.0.1 (not localhost) to match playwright.config.ts baseURL.
+      # Mismatched hosts split cookie scope: login sets cookies on 127.0.0.1
+      # but cross-origin fetches to localhost don't send them, producing 401s
+      # on every authed API request from browser tests.
+      BETTER_AUTH_URL: http://127.0.0.1:3000
+      NEXT_PUBLIC_API_URL: http://127.0.0.1:4000
     services:
       postgres:
         image: postgres:16

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -29,7 +29,19 @@ const resolveBaseUrl = (): string => {
 };
 
 const defaultTrustedOrigins = () => {
-  const origins = ["http://localhost:3000", "http://localhost:3001", "http://localhost:4000"];
+  // Both `localhost` and `127.0.0.1` are loopback but Better Auth's origin
+  // check is exact-string. CI's playwright config uses `127.0.0.1` explicitly
+  // (Node ≥18 resolves `localhost` to `::1` first; servers bind to 0.0.0.0/IPv4
+  // and undici doesn't fall back), so omitting the IPv4 form rejects every
+  // request from those tests with `[Better Auth]: Invalid origin`.
+  const origins = [
+    "http://localhost:3000",
+    "http://localhost:3001",
+    "http://localhost:4000",
+    "http://127.0.0.1:3000",
+    "http://127.0.0.1:3001",
+    "http://127.0.0.1:4000",
+  ];
 
   const portlessNames = ["acme.web", "acme.landing", "acme.api"];
   for (const name of portlessNames) {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -80,7 +80,10 @@ export default defineConfig({
           stderr: "pipe",
           stdout: "pipe",
           timeout: 120_000,
-          url: webUrl,
+          // Probe `/login` (returns 200) — web has no `/` route, so probing the
+          // root URL would 404 forever and Playwright would never proceed to
+          // spawn the api/landing webServers.
+          url: `${webUrl}/login`,
         },
         {
           command: "node apps/api/dist/index.mjs",


### PR DESCRIPTION
## Summary

Fixes 15+ consecutive failing e2e runs on \`main\` (since 2026-04-22). Two distinct root causes — both confirmed via local repro with \`CI=true pnpm test:e2e\`.

## Root cause 1 — webServer probe URL 404

Playwright's web webServer URL probe pointed at \`http://127.0.0.1:3000/\`. The web app has no \`/\` route — it returns **404**. Playwright treats 404 as "not ready" and retries forever.

Critically, Playwright 1.59 starts \`webServer\` array entries **sequentially** (despite docs implying parallel) — readiness of entry N must succeed before entry N+1 spawns. Since web's probe never succeeded, the api and landing webServers were never spawned at all.

**Fix**: probe \`/login\` (a route that exists and returns 200) instead of \`/\`. Verified locally:

\`\`\`
Starting WebServer process node_modules/.bin/next start apps/web --port 3000...
HTTP Status: 200 (on /login)              ← was 404 forever
WebServer available
Starting WebServer process node apps/api/dist/index.mjs...
HTTP Status: 200 (on /healthz)
Starting WebServer process node_modules/.bin/next start apps/landing --port 3001...
HTTP Status: 200 (on /)
\`\`\`

## Root cause 2 — Better Auth rejects \`http://127.0.0.1\` origin

After fix 1 unblocked the webServer setup, the auth setup test progressed to login but failed with:

\`\`\`
[Better Auth]: Invalid origin: http://127.0.0.1:3000
\`\`\`

The playwright config uses \`127.0.0.1\` explicitly (intentional, dodges Node ≥18's IPv6-first \`localhost\` resolution which doesn't fall back to IPv4 in undici). But \`defaultTrustedOrigins\` only listed \`http://localhost:*\` — Better Auth's origin check is exact-string, so every browser request from playwright was rejected.

**Fix**: add \`http://127.0.0.1:{3000,3001,4000}\` to the default trusted-origins list. Verified locally — \`pnpm test:e2e --project=setup\` passes:

\`\`\`
Running 1 test using 1 worker
·
  1 passed (4.0s)
\`\`\`

## Files changed

- \`playwright.config.ts\` — web probe URL → \`\${webUrl}/login\`
- \`packages/auth/src/server.ts\` — \`defaultTrustedOrigins\` adds 127.0.0.1 variants

## Test plan

- [x] Local \`CI=true pnpm test:e2e --project=setup\` — passes
- [x] All 3 webServers spawn and become ready under CI=true
- [ ] CI green on this PR (acme e2e workflow)
- [ ] After merge: \`main\` e2e green for the first time since 2026-04-22

## Related history

The previous fix (commit \`366363f\`, "fix(e2e): unblock CI webServer + healthcheck") correctly diagnosed an earlier pnpm-lock contention issue — that fix remains in place and is still correct. The two failure modes here are distinct from that one.