### PR TITLE
chore: untrack auto-generated files + anchor /agents/ pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,5 @@ logs/
 *.rdb
 
 # agent output
-agents/
+/agents/
 .fallow/

--- a/apps/landing/next-env.d.ts
+++ b/apps/landing/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Caught by the new orchestrator verifier \`verify-no-tracked-ignored.sh\` — files tracked in git that match a .gitignore pattern, the kind of drift that produced collabtime's 16 stale prisma-generated files.

## Changes

- **Untracks** \`apps/landing/next-env.d.ts\` + \`apps/web/next-env.d.ts\`. Both match \`next-env.d.ts\` in the canonical .gitignore but were tracked from before that line landed. Next.js regenerates them on every dev/build, so each version bump produced a noisy diff.
- **Anchors** \`agents/\` → \`/agents/\` in .gitignore. The bare form was a fleet-wide canonical pattern that accidentally matched any subdirectory named \"agents\" (real source code in localcine).

## Test plan

- [x] \`git ls-files -i --exclude-standard -c\` returns empty after change
- [ ] CI green on this PR
- [ ] Fresh \`pnpm install\` regenerates \`next-env.d.ts\` (postinstall is unchanged)

## Related

- Orchestrator: \`6e7f93e\` (dotfiles) adds the verifier; \`73b7f2a\` (orchestrator) updates standards.md
- Sibling cleanup PRs: collabtime #75, localcine + frow open in parallel