### PR TITLE
fix(e2e): opt out of authed storageState for login form tests

### DIFF
--- a/tests/e2e/auth/login.spec.ts
+++ b/tests/e2e/auth/login.spec.ts
@@ -6,6 +6,8 @@ const TEST_USER = {
 };
 
 test.describe("Login", () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
   test("logs in with valid credentials", async ({ loginPage, page }) => {
     await loginPage.goto();
     await loginPage.login(TEST_USER.email, TEST_USER.password);
@@ -28,7 +30,9 @@ test.describe("Login", () => {
 
     await loginPage.expectErrorVisible();
   });
+});
 
+test.describe("Login (already authenticated)", () => {
   test("redirects to dashboard if already authenticated", async ({ page }) => {
     // storageState from setup means we're already logged in
     await page.goto("/login");


### PR DESCRIPTION
## Summary

Pre-existing test bug surfaced by the recently-fixed e2e infra (#52, #54). The login.spec.ts tests didn't opt out of the auth fixture's storageState. Loading \`/login\` in a fresh test context immediately redirected to \`/dashboard\` → email field never appeared → 30s timeout.

Was hidden previously because acme e2e was timing out at the webServer-setup phase (before any tests ran). Now that webServers spawn correctly + cookie scope is fixed, tests actually run and these latent failures surface.

## Fix

Adopts the **same fleet-canonical pattern** used by localcine + frow:

\`\`\`typescript
test.describe("Login", () => {
  test.use({ storageState: { cookies: [], origins: [] } });
  // ... unauth tests
});

test.describe("Login (already authenticated)", () => {
  // default authed storageState from the fixture
  // ... redirect-when-authed test
});
\`\`\`

Spec-level opt-out is cleaner than per-test \`clearCookies()\` — declarative, signals intent at the file level, no boilerplate. Brings acme in line with the other 3 repos that already do this.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, acme #53 + #54 should rebase + go green

## Why a separate PR (not folded into #53/#54)

Neither #53 (untrack auto-generated) nor #54 (auth-form hook) introduces these failures. They just expose them. Keeping the fix focused so the audit trail is clear.