### PR TITLE
docs(readme): add complete setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,11 @@ Monorepo template for all projects. Source of truth for shared patterns, tooling
 
 ## Apps
 
-| App        | Description              | Port |
-| ---------- | ------------------------ | ---- |
-| `web`      | Main application         | 3000 |
-| `api`      | Hono backend API         | 4000 |
-| `landing`  | Marketing site           | 3001 |
-| `workshop` | Storybook component docs | 6006 |
+| App       | Description      | Dev URL                          |
+| --------- | ---------------- | -------------------------------- |
+| `web`     | Main application | `https://acme.web.localhost`     |
+| `api`     | Hono backend API | `https://acme.api.localhost`     |
+| `landing` | Marketing site   | `https://acme.landing.localhost` |
 
 ## Packages
 
@@ -30,15 +29,96 @@ Monorepo template for all projects. Source of truth for shared patterns, tooling
 | `@repo/ui`                | Shared React component library |
 | `@repo/db`                | Prisma database client         |
 | `@repo/auth`              | Authentication module          |
-| `@repo/config-typescript` | Shared TypeScript configs      |
-| `@repo/config-tailwind`   | Shared Tailwind CSS config     |
+| `@repo/typescript-config` | Shared TypeScript configs      |
 | `@repo/config-vitest`     | Shared Vitest test configs     |
 
-## Development
+## Setup
+
+### Prerequisites
+
+- **Node.js 24** (use `nvm install 24 && nvm use 24`)
+- **pnpm 10** (`npm install -g pnpm@10`)
+- **PostgreSQL** running locally on `:5432` (or use Docker — see below)
+- **portless** for stable HTTPS dev URLs (see step 2)
+
+### 1. Install dependencies
 
 ```bash
 pnpm install
+```
+
+### 2. Install portless and start the HTTPS proxy
+
+Dev servers run behind [portless](https://www.npmjs.com/package/portless), which gives each app a stable `https://*.localhost` URL instead of a random port. This is required — the dev scripts wrap each app in `portless run …`, and Better Auth's secure cookies + CORS allowlists assume the portless hostnames.
+
+One-time per machine:
+
+```bash
+npm install -g portless
+sudo portless proxy start --https   # binds :443, trusts the local cert
+```
+
+The proxy auto-restarts on subsequent boots once trusted.
+
+### 3. Start PostgreSQL
+
+If you don't already have Postgres running:
+
+```bash
+docker run -d --name acme-pg \
+  -e POSTGRES_USER=acme \
+  -e POSTGRES_PASSWORD=acme123 \
+  -e POSTGRES_DB=acme \
+  -p 5432:5432 \
+  postgres:16
+```
+
+### 4. Configure environment variables
+
+Copy the root example and generate a Better Auth secret:
+
+```bash
+cp .env.example .env
+```
+
+Then edit `.env` and set:
+
+- `BETTER_AUTH_SECRET` — any 32+ char random string. Generate with `openssl rand -base64 32`.
+- `DATABASE_URL` — must match your Postgres setup. The default in `.env.example` works with the Docker command above.
+
+The other variables (`API_URL`, `NEXT_PUBLIC_API_URL`, `CORS_ORIGINS`, `TRUSTED_ORIGINS`, `BETTER_AUTH_URL`) are pre-set to the portless URLs and don't need changes for local dev.
+
+> **Note:** Per-app `.env.example` files inside `apps/api/` and `apps/web/` are legacy and reference `localhost:PORT` URLs that don't match the portless setup. Use the root `.env` only.
+
+### 5. Initialize the database
+
+```bash
+pnpm db:generate    # generate the Prisma client
+pnpm db:push        # apply the schema to your database
+pnpm db:seed        # optional: seed sample data
+```
+
+### 6. Run the dev servers
+
+```bash
 pnpm dev
+```
+
+Open:
+
+- Web: <https://acme.web.localhost>
+- Landing: <https://acme.landing.localhost>
+- API: <https://acme.api.localhost>
+  - OpenAPI docs (Scalar): <https://acme.api.localhost/docs>
+  - Schema JSON: <https://acme.api.localhost/openapi.json>
+
+### Worktrees
+
+Branch name auto-prefixes the subdomain — concurrent worktrees don't collide:
+
+```
+main worktree:        https://acme.web.localhost
+branch fix-styles:    https://fix-styles.acme.web.localhost
 ```
 
 ## Scripts


### PR DESCRIPTION
## Summary

The README's only setup guidance was `pnpm install && pnpm dev`, which fails on a fresh clone because every dev script is wrapped in `portless run …` and no `.env` exists yet. This PR fills in the missing steps and corrects a few stale references.

### What's added
- **Prerequisites** section (Node 24, pnpm 10, Postgres, portless)
- **Step-by-step setup**: install deps → install portless + start HTTPS proxy → start Postgres (Docker one-liner) → copy `.env` and generate `BETTER_AUTH_SECRET` → `db:generate` / `db:push` / `db:seed` → `pnpm dev`
- **Dev URLs** (`https://acme.web.localhost`, etc.) and OpenAPI/Scalar links
- **Worktree** subdomain prefixing note
- **Troubleshooting** section for the most common gotchas (missing portless, cert warnings, DB connection, auth cookies)

### Stale references fixed
- Removed `workshop` app (doesn't exist in `apps/`)
- Renamed `@repo/config-typescript` → `@repo/typescript-config` (matches actual package name)
- Removed `@repo/config-tailwind` (no such package in `packages/`)
- Replaced `Port` column with `Dev URL` column to match the portless-based setup

### Note
The per-app `.env.example` files in `apps/api/` and `apps/web/` still reference `localhost:PORT` URLs that conflict with the portless setup. Called out in the README as "legacy — use the root `.env` only." Cleaning those up is out of scope here but worth a follow-up.

## Test plan

- [x] On a fresh clone, follow the README steps end-to-end
- [x] Confirm `pnpm dev` brings up `web`, `api`, and `landing` at their portless URLs
- [x] Confirm `https://acme.api.localhost/docs` renders the Scalar UI
- [ ] Confirm sign-up/sign-in works (validates Better Auth cookies + CORS via portless URLs)