### PR TITLE
ci(e2e): split playwright install + retry install-deps

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,9 +57,23 @@ jobs:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ steps.pw.outputs.version }}
       - if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps
-      - if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps
+        run: pnpm exec playwright install
+      # System deps come from apt; Ubuntu mirrors occasionally fail mid-sync
+      # ("File has unexpected size... Mirror sync in progress?"). Retry up to
+      # 3 times with apt-get update in between to ride out transient mirror flaps.
+      - name: Install Playwright system deps
+        run: |
+          attempt=0
+          until pnpm exec playwright install-deps; do
+            attempt=$((attempt + 1))
+            if [ "$attempt" -ge 3 ]; then
+              echo "playwright install-deps failed after $attempt attempts"
+              exit 1
+            fi
+            echo "apt fetch failed (attempt $attempt); retrying in 30s..."
+            sleep 30
+            sudo apt-get update || true
+          done
       - run: pnpm test:e2e
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary

- Combined `playwright install --with-deps` collapsed two failure modes into one step: a cacheable browser download and an apt-driven system-deps install that re-runs every workflow because system libs don't persist between ephemeral Blacksmith runners.
- Split them: cache-miss runs `playwright install` (browsers); a separate always-run step does `install-deps` inside a 3-attempt retry loop with `sudo apt-get update` between tries, riding out "Mirror sync in progress" flaps that have been turning otherwise-green runs red.
- Mirrors the fix already merged in frow-monorepo (frow#146). Standardizes the pattern across acme/collabtime/localcine/frow.

## Test plan
- [ ] Watch CI green on this PR (cold cache → exercises both new steps)
- [ ] Re-run once if CI hits a transient apt mirror flap to confirm retry loop works