### PR TITLE
fix(e2e): isolate logout tests from the shared session

### DIFF
--- a/tests/e2e/auth/logout.spec.ts
+++ b/tests/e2e/auth/logout.spec.ts
@@ -1,8 +1,32 @@
-import { test, expect } from "../fixtures/auth.fixture";
+import type { APIRequestContext } from "@playwright/test";
+
+import { webUrl } from "../../../playwright.config";
+import { expect, test } from "../fixtures/auth.fixture";
+
+const PASSWORD = "TestPassword123!";
+
+// Logout invalidates the session row in the database. If these tests reused the
+// shared `e2e-test@acme.localhost` user from the setup project, the moment one
+// of them ran, every other test sharing that storageState would 401 once the
+// 5-minute Better Auth cookie cache expired (packages/auth/src/server.ts:193).
+// So each logout test owns a freshly created user instead.
+const createIsolatedUser = async (request: APIRequestContext): Promise<string> => {
+  const email = `logout-test-${crypto.randomUUID()}@acme.localhost`;
+  const response = await request.post(`${webUrl}/api/auth/sign-up/email`, {
+    data: { email, name: "Logout Test User", password: PASSWORD },
+  });
+  expect([200, 201]).toContain(response.status());
+  return email;
+};
 
 test.describe("Logout", () => {
-  test("signs out and redirects to login", async ({ dashboardPage, page }) => {
-    await dashboardPage.goto();
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("signs out and redirects to login", async ({ dashboardPage, loginPage, page, request }) => {
+    const email = await createIsolatedUser(request);
+    await loginPage.goto();
+    await loginPage.login(email, PASSWORD);
+    await page.waitForURL("/dashboard");
     await dashboardPage.expectHeadingVisible();
 
     await dashboardPage.signOut();
@@ -11,8 +35,17 @@ test.describe("Logout", () => {
     expect(page.url()).toContain("/login");
   });
 
-  test("cannot access dashboard after logout", async ({ dashboardPage, page }) => {
-    await dashboardPage.goto();
+  test("cannot access dashboard after logout", async ({
+    dashboardPage,
+    loginPage,
+    page,
+    request,
+  }) => {
+    const email = await createIsolatedUser(request);
+    await loginPage.goto();
+    await loginPage.login(email, PASSWORD);
+    await page.waitForURL("/dashboard");
+
     await dashboardPage.signOut();
     await page.waitForURL("/login");
 


### PR DESCRIPTION
## Summary

The e2e suite has been failing in CI for a while — chromium runs partway through, then everything times out for ~12 minutes, then firefox and webkit both 401 on every authed request.

### Root cause

`tests/e2e/auth/logout.spec.ts` was calling Better Auth's `signOut` against the **shared** \`e2e-test@acme.localhost\` user (created once by \`tests/e2e/setup/auth.setup.ts\`). \`signOut\` deletes the session row in Postgres. Every other browser project loads the same \`tests/e2e/.auth/user.json\` storageState, so once the session is gone in the DB, those cookies are dead.

It was hidden for a few minutes by Better Auth's cookie cache (\`packages/auth/src/server.ts:193\`):

\`\`\`ts
cookieCache: { enabled: true, maxAge: 5 * 60 } // 5 minutes
\`\`\`

That cache lets validation skip the DB for 5 minutes — which exactly explains the timing in the failing CI logs:

- t=0: chromium starts, tests pass (cache hit)
- t≈5min: cache expires, tests start failing
- t≈5–17min: tests retry × 30s timeout — quiet on the api logs
- t≈12.5min: firefox starts, every request hits the DB lookup → 401

The 401 stack trace passes through \`cors2\` → both rate limiters → and then \`apps/api/src/middleware/auth.ts:48\`. CORS, rate limit, and env are not involved.

### Fix

Each logout test now signs up its own throwaway \`logout-test-<uuid>@acme.localhost\`, logs in through the UI, and runs against that isolated session. Adding \`test.use({ storageState: { cookies: [], origins: [] } })\` opts the file out of the shared cookies entirely, so the session deletion can never reach back into the user the rest of the suite depends on.

## Adjacent issue (not fixed here)

\`apps/api/src/middleware/security.ts:5-6\` — \`getClientIp\` returns \`\"unknown\"\` for every CI request (no \`x-forwarded-for\`, no \`x-real-ip\`, \`c.env?.remoteAddr\` is \`undefined\` under the Hono Node adapter). Every CI request shares one Hono rate-limit bucket. Not biting today (1 worker stays under the cap), but worth fixing once you bump CI parallelism.

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm format:check\`
- [ ] CI \`e2e.yml\` passes — chromium, firefox, and webkit all green
- [ ] Local: run with \`pnpm test:e2e\` and confirm logout tests pass without invalidating the shared user