### PR TITLE
fix(e2e): point root-error selectors at the actual rendered class

### DIFF
--- a/tests/e2e/pages/login.page.ts
+++ b/tests/e2e/pages/login.page.ts
@@ -11,7 +11,8 @@ export class LoginPage {
     this.emailInput = page.getByLabel(/email/i);
     this.passwordInput = page.getByLabel(/password/i);
     this.submitButton = page.getByRole("button", { name: /sign in|log in/i });
-    this.rootError = page.locator(".text-red-500");
+    // Root errors render via a <p class="text-sm text-destructive"> sibling.
+    this.rootError = page.locator("p.text-destructive");
   }
 
   goto = async () => {

--- a/tests/e2e/pages/recover.page.ts
+++ b/tests/e2e/pages/recover.page.ts
@@ -9,7 +9,8 @@ export class RecoverPage {
   constructor(private readonly page: Page) {
     this.emailInput = page.getByLabel(/email/i);
     this.submitButton = page.getByRole("button", { name: /submit request/i });
-    this.rootError = page.locator(".text-red-500");
+    // Root errors render via a <p class="text-sm text-destructive"> sibling.
+    this.rootError = page.locator("p.text-destructive");
   }
 
   goto = async () => {

--- a/tests/e2e/pages/register.page.ts
+++ b/tests/e2e/pages/register.page.ts
@@ -15,7 +15,8 @@ export class RegisterPage {
     this.passwordInput = page.getByLabel("Password", { exact: true });
     this.confirmPasswordInput = page.getByLabel(/confirm password/i);
     this.submitButton = page.getByRole("button", { name: /register/i });
-    this.rootError = page.locator(".text-red-500");
+    // Root errors render via a <p class="text-sm text-destructive"> sibling.
+    this.rootError = page.locator("p.text-destructive");
   }
 
   goto = async () => {


### PR DESCRIPTION
## Summary

The login / recover / register page objects waited on \`.text-red-500\`, a class that exists nowhere in the app. The auth forms render root errors as \`<p class=\"text-sm text-destructive\">…</p>\` (e.g. \`apps/web/src/app/(auth)/login/form.tsx:104\`). \`reset-password.page.ts\` already uses \`p.text-destructive\` — these three were missed when the className changed (presumably during the auth-form refactor in #54).

### Why this is the actual CI blocker

PR #59 fixed one half of the e2e failure (logout invalidating the shared session). But the suite never made it that far in CI — it was already burning all 30 minutes of job time on retries of the negative-credential tests:

- \"shows error for wrong password\" (login)
- \"rejects invalid email format\" / etc. (register)
- equivalent paths in recover

Each of those submits bad credentials, the form does render the error correctly, but \`expectErrorVisible()\` waits 30s on a selector that never matches, then retries twice. Across 3 browsers × the affected negative tests × 30s × 3 attempts, the budget is gone before the auth suite even starts.

### Stacks with #59

This PR alone is not enough; #59 alone is not enough either. With both merged, the suite should actually be able to run end-to-end and reveal whatever (if anything) is left.

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm format:check\`
- [ ] Once both this PR and #59 land, CI \`e2e.yml\` completes within the timeout for chromium / firefox / webkit