### PR TITLE
feat: scaffold @repo/transactional package mirroring frow

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@repo/db": "workspace:*",
-    "better-auth": "^1.6.9",
-    "resend": "^6.12.2"
+    "@repo/transactional": "workspace:*",
+    "better-auth": "^1.6.9"
   },
   "devDependencies": {
     "@repo/config-vitest": "workspace:*",

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -1,6 +1,11 @@
 import { execFileSync } from "node:child_process";
 
 import type { PrismaClient } from "@repo/db";
+import {
+  sendPasswordResetEmail,
+  sendSignUpAttemptEmail,
+  sendWelcomeEmail,
+} from "@repo/transactional";
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { bearer } from "better-auth/plugins/bearer";
@@ -117,24 +122,22 @@ export const createAuth = (config: AuthConfig) => {
       // arrive. See better-auth docs "Email Enumeration Protection".
       onExistingUserSignUp: resendApiKey
         ? async ({ user }, request) => {
-            // Derive the web origin from the signup request (CORS already
-            // validated it via trustedOrigins) so the email links back to the
-            // app the user actually came from.
             const origin = request?.headers.get("origin") ?? "";
-            const { Resend } = await import("resend");
-            const resend = new Resend(resendApiKey);
-            const { error } = await resend.emails.send({
-              from: fromEmail,
-              html: `<p>Someone tried to create a new acme account using your email address (${user.email}). If this was you, <a href="${origin}/login">sign in</a> or <a href="${origin}/recover">reset your password</a> instead. If not, you can safely ignore this email — no account changes were made.</p>`,
-              subject: "Sign-up attempt with your acme account",
-              to: user.email,
-            });
-            if (error) {
+            const result = await sendSignUpAttemptEmail(
+              {
+                resetPasswordUrl: `${origin}/recover`,
+                signInUrl: `${origin}/login`,
+                userEmail: user.email,
+                username: user.name,
+              },
+              { apiKey: resendApiKey, from: fromEmail },
+            );
+            if (!result.success) {
               // Don't throw — Better Auth's enumeration-prevention path needs
               // to return success regardless. Log so delivery failures don't
               // break the auth response.
-              // eslint-disable-next-line no-console -- temporary until a structured logger lands
-              console.error("[Auth] Failed to send sign-up attempt email:", error);
+              // oxlint-disable-next-line no-console -- temporary until a structured logger lands
+              console.error("[Auth] Failed to send sign-up attempt email:", result.error);
             }
           }
         : undefined,
@@ -145,16 +148,16 @@ export const createAuth = (config: AuthConfig) => {
       requireEmailVerification: Boolean(resendApiKey),
       sendResetPassword: resendApiKey
         ? async ({ url, user }) => {
-            const { Resend } = await import("resend");
-            const resend = new Resend(resendApiKey);
-            const { error } = await resend.emails.send({
-              from: fromEmail,
-              html: `<p>Click <a href="${url}">here</a> to reset your password.</p>`,
-              subject: "Reset your password",
-              to: user.email,
-            });
-            if (error) {
-              throw new Error(`Failed to send password reset email: ${error.message}`);
+            const result = await sendPasswordResetEmail(
+              {
+                resetUrl: url,
+                userEmail: user.email,
+                username: user.name,
+              },
+              { apiKey: resendApiKey, from: fromEmail },
+            );
+            if (!result.success) {
+              throw new Error(`Failed to send password reset email: ${result.error}`);
             }
           }
         : undefined,
@@ -163,16 +166,16 @@ export const createAuth = (config: AuthConfig) => {
     emailVerification: {
       sendVerificationEmail: resendApiKey
         ? async ({ url, user }) => {
-            const { Resend } = await import("resend");
-            const resend = new Resend(resendApiKey);
-            const { error } = await resend.emails.send({
-              from: fromEmail,
-              html: `<p>Click <a href="${url}">here</a> to verify your email address.</p>`,
-              subject: "Verify your email address",
-              to: user.email,
-            });
-            if (error) {
-              throw new Error(`Failed to send verification email: ${error.message}`);
+            const result = await sendWelcomeEmail(
+              {
+                userEmail: user.email,
+                username: user.name,
+                verificationUrl: url,
+              },
+              { apiKey: resendApiKey, from: fromEmail },
+            );
+            if (!result.success) {
+              throw new Error(`Failed to send verification email: ${result.error}`);
             }
           }
         : undefined,

--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@repo/transactional",
+  "version": "0.0.0",
+  "private": true,
+  "files": [
+    "dist/**"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "lint": "oxlint src",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "preview": "portless run --force --name acme.email -- bash -c 'email dev --port $PORT --dir ./src'"
+  },
+  "dependencies": {
+    "resend": "^6.12.2",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@react-email/ui": "^6.0.5",
+    "@repo/config-vitest": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "react-email": "^6.0.5",
+    "tsdown": "^0.21.10",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "peerDependencies": {
+    "react": "^18.3.1 || ^19.0.0",
+    "react-dom": "^18.3.1 || ^19.0.0"
+  }
+}

--- a/packages/transactional/src/client.ts
+++ b/packages/transactional/src/client.ts
@@ -1,0 +1,10 @@
+import { Resend } from "resend";
+
+const createResendClient = (apiKey: string) => {
+  if (!apiKey) {
+    throw new Error("RESEND_API_KEY is not provided");
+  }
+  return new Resend(apiKey);
+};
+
+export { createResendClient };

--- a/packages/transactional/src/components/acme-logo.tsx
+++ b/packages/transactional/src/components/acme-logo.tsx
@@ -1,0 +1,14 @@
+import { Img } from "react-email";
+
+type AcmeLogoProps = {
+  height?: number;
+  width?: number;
+};
+
+const AcmeLogo = ({ height = 32, width = 120 }: AcmeLogoProps) => {
+  return (
+    <Img alt="Acme" height={height} src="https://www.acme.com/logo-wordmark.svg" width={width} />
+  );
+};
+
+export { AcmeLogo };

--- a/packages/transactional/src/components/button.tsx
+++ b/packages/transactional/src/components/button.tsx
@@ -1,0 +1,28 @@
+import { Button as EmailButton } from "react-email";
+
+type ButtonProps = {
+  children: React.ReactNode;
+  fullWidth?: boolean;
+  href: string;
+  variant?: "primary" | "outline";
+};
+
+const Button = ({ children, fullWidth = false, href, variant = "primary" }: ButtonProps) => {
+  const baseClasses =
+    "box-border rounded-lg px-5 py-3 text-center text-base font-semibold no-underline break-words whitespace-normal";
+
+  const variantClasses = {
+    outline: "border border-border bg-card text-foreground",
+    primary: "bg-primary text-primary-foreground",
+  };
+
+  const widthClass = fullWidth ? "block w-full max-w-full" : "inline-block";
+
+  return (
+    <EmailButton className={`${baseClasses} ${variantClasses[variant]} ${widthClass}`} href={href}>
+      {children}
+    </EmailButton>
+  );
+};
+
+export { Button };

--- a/packages/transactional/src/components/card.tsx
+++ b/packages/transactional/src/components/card.tsx
@@ -1,0 +1,24 @@
+import { Section, Text } from "react-email";
+
+type CardProps = {
+  accent?: boolean;
+  children: React.ReactNode;
+  title?: string;
+};
+
+const Card = ({ accent = false, children, title }: CardProps) => {
+  const accentClasses = accent ? "border-l-4 border-l-primary" : "";
+
+  return (
+    <Section className={`rounded-lg border border-border bg-card p-5 break-words ${accentClasses}`}>
+      {title && (
+        <Text className="m-0 mb-2 text-base font-semibold break-words text-foreground">
+          {title}
+        </Text>
+      )}
+      <div className="break-words">{children}</div>
+    </Section>
+  );
+};
+
+export { Card };

--- a/packages/transactional/src/components/divider.tsx
+++ b/packages/transactional/src/components/divider.tsx
@@ -1,0 +1,21 @@
+import { Hr } from "react-email";
+
+type DividerProps = {
+  spacing?: "sm" | "md" | "lg";
+};
+
+const Divider = ({ spacing = "md" }: DividerProps) => {
+  const spacingClasses = {
+    lg: "py-5",
+    md: "py-4",
+    sm: "py-3",
+  };
+
+  return (
+    <div className={spacingClasses[spacing]}>
+      <Hr className="m-0 border-border" />
+    </div>
+  );
+};
+
+export { Divider };

--- a/packages/transactional/src/components/index.ts
+++ b/packages/transactional/src/components/index.ts
@@ -1,0 +1,4 @@
+export { AcmeLogo } from "./acme-logo";
+export { Button } from "./button";
+export { Card } from "./card";
+export { Divider } from "./divider";

--- a/packages/transactional/src/emails/base-layout.tsx
+++ b/packages/transactional/src/emails/base-layout.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+import { Body, Container, Head, Html, Link, Preview, Section, Tailwind, Text } from "react-email";
+
+import { AcmeLogo } from "../components";
+import { tailwindConfig } from "../styles/theme";
+
+type BaseLayoutProps = {
+  children: React.ReactNode;
+  footerText?: string;
+  preview: string;
+  unsubscribeUrl?: string;
+};
+
+const BaseLayout = ({
+  children,
+  footerText = "You're receiving this email because you have an account with Acme.",
+  preview,
+  unsubscribeUrl,
+}: BaseLayoutProps) => {
+  return (
+    <Html>
+      <Tailwind config={tailwindConfig}>
+        <Head>
+          <meta content="width=device-width, initial-scale=1" name="viewport" />
+          <meta name="x-apple-disable-message-reformatting" />
+          <meta content="light" name="color-scheme" />
+          <meta content="light" name="supported-color-schemes" />
+        </Head>
+        <Preview>{preview}</Preview>
+        <Body className="m-0 bg-muted p-4 font-sans">
+          <Container className="mx-auto w-full max-w-[600px] overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+            {/* Header */}
+            <Section className="bg-primary px-6 py-8 text-center">
+              <Link className="inline-block no-underline" href="https://acme.com">
+                <AcmeLogo height={28} width={104} />
+              </Link>
+            </Section>
+
+            {/* Content */}
+            <Section className="px-6 py-8">
+              <div className="break-words">{children}</div>
+            </Section>
+
+            {/* Footer */}
+            <Section className="border-t border-border bg-muted px-6 py-8 text-center">
+              <Text className="m-0 mb-4 text-sm text-muted-foreground">{footerText}</Text>
+
+              <Text className="mb-4 text-sm text-muted-foreground">
+                <Link
+                  className="text-sm font-semibold text-foreground no-underline"
+                  href="https://acme.com"
+                >
+                  Visit Acme
+                </Link>
+                {unsubscribeUrl && (
+                  <>
+                    <span className="px-2 text-sm text-border">·</span>
+                    <Link
+                      className="text-sm font-semibold text-muted-foreground no-underline"
+                      href={unsubscribeUrl}
+                    >
+                      Unsubscribe
+                    </Link>
+                  </>
+                )}
+              </Text>
+
+              <Text className="m-0 text-xs text-muted-foreground">
+                © {new Date().getFullYear()} Acme. All rights reserved.
+              </Text>
+            </Section>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+export { BaseLayout };

--- a/packages/transactional/src/emails/password-reset.tsx
+++ b/packages/transactional/src/emails/password-reset.tsx
@@ -1,0 +1,74 @@
+import { Heading, Link, Text } from "react-email";
+
+import { Button, Card, Divider } from "../components";
+
+import { BaseLayout } from "./base-layout";
+
+type PasswordResetEmailProps = {
+  browserInfo?: string;
+  ipAddress?: string;
+  resetUrl: string;
+  userEmail: string;
+  username?: string;
+};
+
+const PasswordResetEmail = ({
+  browserInfo,
+  ipAddress,
+  resetUrl,
+  userEmail,
+  username,
+}: PasswordResetEmailProps) => {
+  return (
+    <BaseLayout preview="Reset your Acme password">
+      <Heading className="mt-0 mb-4 text-2xl font-semibold tracking-tight text-balance break-words text-foreground">
+        Reset your password
+      </Heading>
+
+      <Text className="m-0 mb-2 text-base text-pretty break-words text-muted-foreground">
+        Hi{username ? ` ${username}` : ""},
+      </Text>
+
+      <Text className="m-0 mb-6 text-base text-pretty break-words text-muted-foreground">
+        We received a request to reset the password on your Acme account. If you made this request,
+        use the button below to set a new password.
+      </Text>
+
+      <div className="mb-6">
+        <Button fullWidth href={resetUrl} variant="primary">
+          Reset password
+        </Button>
+      </div>
+
+      <Divider />
+
+      <Card accent title="Request details">
+        <ul className="m-0 list-none p-0 text-base text-muted-foreground">
+          <li className="py-1">Email: {userEmail}</li>
+          {ipAddress && <li className="py-1">IP address: {ipAddress}</li>}
+          {browserInfo && <li className="py-1">Browser: {browserInfo}</li>}
+        </ul>
+        <Text className="m-0 mt-3 mb-2 text-base font-semibold text-foreground">Important</Text>
+        <ul className="m-0 list-inside list-disc text-base text-muted-foreground">
+          <li className="py-1">This link expires in 1 hour</li>
+          <li className="py-1">It can only be used once</li>
+          <li className="py-1">If you didn&apos;t request this, secure your account</li>
+        </ul>
+      </Card>
+
+      <Divider spacing="sm" />
+
+      <Text className="m-0 text-xs text-muted-foreground">
+        If the button above doesn&apos;t work, copy and paste this link into your browser:
+        <br />
+        <Link className="break-all text-foreground underline" href={resetUrl}>
+          {resetUrl}
+        </Link>
+      </Text>
+    </BaseLayout>
+  );
+};
+
+export { PasswordResetEmail };
+// fallow-ignore-next-line unused-export
+export default PasswordResetEmail;

--- a/packages/transactional/src/emails/sign-up-attempt.tsx
+++ b/packages/transactional/src/emails/sign-up-attempt.tsx
@@ -1,0 +1,88 @@
+import { Heading, Link, Text } from "react-email";
+
+import { Button, Card, Divider } from "../components";
+
+import { BaseLayout } from "./base-layout";
+
+type SignUpAttemptEmailProps = {
+  resetPasswordUrl: string;
+  signInUrl: string;
+  userEmail: string;
+  username?: string;
+};
+
+const SignUpAttemptEmail = ({
+  resetPasswordUrl,
+  signInUrl,
+  userEmail,
+  username,
+}: SignUpAttemptEmailProps) => {
+  return (
+    <BaseLayout preview="A sign-up attempt was made with your Acme account email">
+      <Heading className="mt-0 mb-4 text-2xl font-semibold tracking-tight text-balance break-words text-foreground">
+        Did you try to sign up?
+      </Heading>
+
+      <Text className="m-0 mb-2 text-base text-pretty break-words text-muted-foreground">
+        Hi{username ? ` ${username}` : ""},
+      </Text>
+
+      <Text className="m-0 mb-2 text-base text-pretty break-words text-muted-foreground">
+        Someone just tried to create a new Acme account using your email (
+        <strong>{userEmail}</strong>). You already have an account with us, so we didn&apos;t create
+        a new one.
+      </Text>
+
+      <Text className="m-0 mb-6 text-base text-pretty break-words text-muted-foreground">
+        If this was you, sign in to your existing account below. If you forgot your password, you
+        can reset it.
+      </Text>
+
+      <div className="mb-6">
+        <Button fullWidth href={signInUrl} variant="primary">
+          Sign in
+        </Button>
+      </div>
+
+      <Text className="m-0 mb-6 text-base text-muted-foreground">
+        Or{" "}
+        <Link className="text-foreground underline" href={resetPasswordUrl}>
+          reset your password
+        </Link>{" "}
+        if you don&apos;t remember it.
+      </Text>
+
+      <Divider />
+
+      <Card accent title="Didn't try to sign up?">
+        <Text className="m-0 mb-2 text-base text-muted-foreground">
+          You can safely ignore this email — no account changes were made. If you keep getting these
+          notifications, someone may be probing for accounts using your email. We recommend:
+        </Text>
+        <ul className="m-0 list-inside list-disc text-base text-muted-foreground">
+          <li className="py-1">Confirm your email account is secure</li>
+          <li className="py-1">Enable two-factor authentication on Acme</li>
+          <li className="py-1">
+            <Link className="text-foreground underline" href="mailto:security@acme.com">
+              Let our security team know
+            </Link>
+          </li>
+        </ul>
+      </Card>
+
+      <Divider spacing="sm" />
+
+      <Text className="m-0 text-xs text-muted-foreground">
+        If the button above doesn&apos;t work, copy and paste this link into your browser:
+        <br />
+        <Link className="break-all text-foreground underline" href={signInUrl}>
+          {signInUrl}
+        </Link>
+      </Text>
+    </BaseLayout>
+  );
+};
+
+export { SignUpAttemptEmail };
+// fallow-ignore-next-line unused-export
+export default SignUpAttemptEmail;

--- a/packages/transactional/src/emails/welcome.tsx
+++ b/packages/transactional/src/emails/welcome.tsx
@@ -1,0 +1,64 @@
+import { Heading, Link, Text } from "react-email";
+
+import { Button, Divider } from "../components";
+
+import { BaseLayout } from "./base-layout";
+
+type WelcomeEmailProps = {
+  userEmail: string;
+  username?: string;
+  verificationUrl: string;
+};
+
+const WelcomeEmail = ({ userEmail, username, verificationUrl }: WelcomeEmailProps) => {
+  return (
+    <BaseLayout preview="Welcome to Acme. Verify your email to get started.">
+      <Heading className="mt-0 mb-4 text-2xl font-semibold tracking-tight text-balance break-words text-foreground">
+        Welcome to Acme.
+      </Heading>
+
+      <Text className="m-0 mb-6 text-base text-pretty break-words text-muted-foreground">
+        Glad to have you here. Verify your email to finish setting up your account.
+      </Text>
+
+      <div className="mb-6">
+        <Button fullWidth href={verificationUrl} variant="primary">
+          Verify email address
+        </Button>
+      </div>
+
+      <Divider />
+
+      <Text className="m-0 mb-4 text-sm text-muted-foreground">
+        If you didn&apos;t create an account with Acme, you can safely ignore this email. The
+        verification link expires in 24 hours.
+      </Text>
+
+      <Text className="m-0 mb-4 text-sm text-muted-foreground">
+        <strong>Account details</strong>
+        <br />
+        {username ? (
+          <>
+            Username: {username}
+            <br />
+          </>
+        ) : null}
+        Email: {userEmail}
+      </Text>
+
+      <Divider spacing="sm" />
+
+      <Text className="m-0 text-xs text-muted-foreground">
+        If the button above doesn&apos;t work, copy and paste this link into your browser:
+        <br />
+        <Link className="break-all text-foreground underline" href={verificationUrl}>
+          {verificationUrl}
+        </Link>
+      </Text>
+    </BaseLayout>
+  );
+};
+
+export { WelcomeEmail };
+// fallow-ignore-next-line unused-export
+export default WelcomeEmail;

--- a/packages/transactional/src/index.ts
+++ b/packages/transactional/src/index.ts
@@ -1,0 +1,12 @@
+// Client
+export { createResendClient } from "./client";
+
+// Components
+export * from "./components";
+
+// Utilities
+export { sendEmail, sendBatchEmails, previewEmail } from "./utils/send-email";
+export { sendWelcomeEmail, sendPasswordResetEmail, sendSignUpAttemptEmail } from "./utils/senders";
+
+// Theme
+export { emailTheme, tailwindConfig } from "./styles/theme";

--- a/packages/transactional/src/styles/theme.ts
+++ b/packages/transactional/src/styles/theme.ts
@@ -1,0 +1,77 @@
+import { pixelBasedPreset } from "react-email";
+
+const emailTheme = {
+  borderRadius: {
+    full: "9999px",
+    lg: "10px",
+    md: "8px",
+    sm: "4px",
+    xl: "16px",
+  },
+  colors: {
+    background: "#ffffff",
+    backgroundDark: "#0a0a0a",
+    border: "#e5e5e5",
+    borderDark: "#282828",
+    error: "#e7000b",
+    primary: "#171717",
+    primaryDark: "#0a0a0a",
+    secondary: "#f5f5f5",
+    secondaryDark: "#e5e5e5",
+    success: "#10b981",
+    text: "#0a0a0a",
+    textDark: "#fafafa",
+    textLight: "#737373",
+    textMuted: "#a1a1a1",
+    warning: "#f59e0b",
+  },
+  fonts: {
+    mono: '"SF Mono", Monaco, Inconsolata, "Fira Code", "Fira Mono", "Roboto Mono", "Courier New", monospace',
+    sans: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+  },
+  spacing: {
+    "2xl": "48px",
+    lg: "24px",
+    md: "16px",
+    sm: "8px",
+    xl: "32px",
+    xs: "4px",
+  },
+};
+
+// Mirrors the shadcn token names from @repo/ui's globals.css so emails can be
+// authored with the same `bg-primary` / `text-muted-foreground` / `border-border`
+// vocabulary as the web app. Email tooling has no CSS variables, so the hex
+// values are resolved here at build time instead of at render time.
+const tailwindConfig = {
+  presets: [pixelBasedPreset],
+  theme: {
+    extend: {
+      colors: {
+        accent: emailTheme.colors.secondary,
+        "accent-foreground": emailTheme.colors.primary,
+        background: emailTheme.colors.background,
+        border: emailTheme.colors.border,
+        card: emailTheme.colors.background,
+        "card-foreground": emailTheme.colors.text,
+        destructive: emailTheme.colors.error,
+        "destructive-foreground": emailTheme.colors.textDark,
+        foreground: emailTheme.colors.text,
+        muted: emailTheme.colors.secondary,
+        "muted-foreground": emailTheme.colors.textLight,
+        primary: emailTheme.colors.primary,
+        "primary-dark": emailTheme.colors.primaryDark,
+        "primary-foreground": emailTheme.colors.textDark,
+        secondary: emailTheme.colors.secondary,
+        "secondary-dark": emailTheme.colors.secondaryDark,
+        "secondary-foreground": emailTheme.colors.primary,
+      },
+      fontFamily: {
+        mono: emailTheme.fonts.mono,
+        sans: emailTheme.fonts.sans,
+      },
+    },
+  },
+};
+
+export { emailTheme, tailwindConfig };

--- a/packages/transactional/src/utils/send-email.ts
+++ b/packages/transactional/src/utils/send-email.ts
@@ -1,0 +1,179 @@
+import type { ReactElement } from "react";
+import { render } from "react-email";
+import { z } from "zod";
+
+import { createResendClient } from "../client";
+
+const emailConfigSchema = z.object({
+  bcc: z.union([z.string().email(), z.array(z.string().email())]).optional(),
+  cc: z.union([z.string().email(), z.array(z.string().email())]).optional(),
+  from: z.string().email().default("Acme <noreply@acme.com>"),
+  replyTo: z.string().email().optional(),
+  subject: z.string(),
+  tags: z
+    .array(
+      z.object({
+        name: z.string(),
+        value: z.string(),
+      }),
+    )
+    .optional(),
+  to: z.union([z.string().email(), z.array(z.string().email())]),
+});
+
+type EmailConfig = z.infer<typeof emailConfigSchema>;
+
+type SendEmailOptions = EmailConfig & {
+  apiKey: string;
+  defaultReplyTo?: string;
+  template: ReactElement;
+};
+
+type PreparedEmailPayload = {
+  bcc?: EmailConfig["bcc"];
+  cc?: EmailConfig["cc"];
+  from: string;
+  html: string;
+  replyTo?: string;
+  subject: string;
+  tags?: EmailConfig["tags"];
+  text: string;
+  to: EmailConfig["to"];
+};
+
+const sendEmail = async ({ apiKey, defaultReplyTo, template, ...config }: SendEmailOptions) => {
+  if (!apiKey) {
+    throw new Error("API key is required for sending emails");
+  }
+
+  try {
+    const validatedConfig = emailConfigSchema.parse(config);
+    const resend = createResendClient(apiKey);
+
+    const html = await render(template);
+    const text = await render(template, { plainText: true });
+
+    const result = await resend.emails.send({
+      bcc: validatedConfig.bcc,
+      cc: validatedConfig.cc,
+      from: validatedConfig.from,
+      html,
+      replyTo: validatedConfig.replyTo || defaultReplyTo,
+      subject: validatedConfig.subject,
+      tags: validatedConfig.tags,
+      text,
+      to: validatedConfig.to,
+    });
+
+    if (result.error) {
+      throw new Error(
+        `Resend failed to queue email: ${result.error.name ?? "unknown_error"} - ${result.error.message ?? "No message"}`,
+      );
+    }
+
+    return {
+      data: result.data,
+      error: null,
+      success: true,
+    };
+  } catch (error) {
+    return {
+      data: null,
+      error: error instanceof Error ? error.message : "Failed to send email",
+      success: false,
+    };
+  }
+};
+
+const sendBatchEmails = async (
+  emails: Array<SendEmailOptions>,
+  apiKey: string,
+  defaultReplyTo?: string,
+) => {
+  if (!apiKey) {
+    throw new Error("API key is required for sending emails");
+  }
+
+  if (emails.length > 100) {
+    throw new Error("Batch size cannot exceed 100 emails");
+  }
+
+  try {
+    const resend = createResendClient(apiKey);
+
+    const settledBatchData = await Promise.allSettled(
+      emails.map(async ({ template, ...config }) => {
+        const validatedConfig = emailConfigSchema.parse(config);
+        const html = await render(template);
+        const text = await render(template, { plainText: true });
+
+        return {
+          bcc: validatedConfig.bcc,
+          cc: validatedConfig.cc,
+          from: validatedConfig.from,
+          html,
+          replyTo: validatedConfig.replyTo || defaultReplyTo,
+          subject: validatedConfig.subject,
+          tags: validatedConfig.tags,
+          text,
+          to: validatedConfig.to,
+        };
+      }),
+    );
+
+    const batchData: Array<PreparedEmailPayload> = [];
+    const rejectionReasons: Array<unknown> = [];
+    const rejectionMessages: Array<string> = [];
+
+    settledBatchData.forEach((result, index) => {
+      if (result.status === "fulfilled") {
+        batchData.push(result.value);
+        return;
+      }
+
+      rejectionReasons.push(result.reason);
+
+      const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      rejectionMessages.push(`email index ${index}: ${reason}`);
+    });
+
+    if (rejectionReasons.length > 0) {
+      throw new AggregateError(
+        rejectionReasons,
+        `Failed to prepare ${rejectionReasons.length} email(s): ${rejectionMessages.join("; ")}`,
+      );
+    }
+
+    const result = await resend.batch.send(batchData);
+
+    if (result.error) {
+      throw new Error(
+        `Resend failed to queue batch: ${result.error.name ?? "unknown_error"} - ${result.error.message ?? "No message"}`,
+      );
+    }
+
+    return {
+      data: result.data,
+      error: null,
+      success: true,
+    };
+  } catch (error) {
+    return {
+      data: null,
+      error: error instanceof Error ? error.message : "Failed to send batch emails",
+      success: false,
+    };
+  }
+};
+
+const previewEmail = async (template: ReactElement) => {
+  const html = await render(template);
+  const text = await render(template, { plainText: true });
+
+  return {
+    html,
+    text,
+  };
+};
+
+export { sendEmail, sendBatchEmails, previewEmail };

--- a/packages/transactional/src/utils/senders.ts
+++ b/packages/transactional/src/utils/senders.ts
@@ -1,0 +1,118 @@
+// oxlint-disable require-await -- email sender functions present an async API for callers; React render itself is sync
+
+import * as React from "react";
+
+import { PasswordResetEmail } from "../emails/password-reset";
+import { SignUpAttemptEmail } from "../emails/sign-up-attempt";
+import { WelcomeEmail } from "../emails/welcome";
+
+import { sendEmail } from "./send-email";
+
+type EmailConfig = {
+  apiKey: string;
+  defaultReplyTo?: string;
+  from?: string;
+};
+
+const DEFAULT_FROM = "Acme <noreply@acme.com>";
+
+const sendWelcomeEmail = async (
+  {
+    userEmail,
+    username,
+    verificationUrl,
+  }: {
+    userEmail: string;
+    username?: string;
+    verificationUrl: string;
+  },
+  config: EmailConfig,
+) => {
+  return sendEmail({
+    apiKey: config.apiKey,
+    defaultReplyTo: config.defaultReplyTo,
+    from: config.from || DEFAULT_FROM,
+    subject: `Welcome to Acme${username ? `, ${username}` : ""}! Please verify your email`,
+    tags: [
+      { name: "type", value: "welcome" },
+      ...(username ? [{ name: "username", value: username }] : []),
+    ],
+    template: React.createElement(WelcomeEmail, {
+      userEmail,
+      username,
+      verificationUrl,
+    }),
+    to: userEmail,
+  });
+};
+
+const sendSignUpAttemptEmail = async (
+  {
+    resetPasswordUrl,
+    signInUrl,
+    userEmail,
+    username,
+  }: {
+    resetPasswordUrl: string;
+    signInUrl: string;
+    userEmail: string;
+    username?: string;
+  },
+  config: EmailConfig,
+) => {
+  return sendEmail({
+    apiKey: config.apiKey,
+    defaultReplyTo: config.defaultReplyTo,
+    from: config.from || DEFAULT_FROM,
+    subject: "Sign-up attempt with your Acme account",
+    tags: [
+      { name: "type", value: "sign-up-attempt" },
+      ...(username ? [{ name: "username", value: username }] : []),
+    ],
+    template: React.createElement(SignUpAttemptEmail, {
+      resetPasswordUrl,
+      signInUrl,
+      userEmail,
+      username,
+    }),
+    to: userEmail,
+  });
+};
+
+const sendPasswordResetEmail = async (
+  {
+    browserInfo,
+    ipAddress,
+    resetUrl,
+    userEmail,
+    username,
+  }: {
+    browserInfo?: string;
+    ipAddress?: string;
+    resetUrl: string;
+    userEmail: string;
+    username?: string;
+  },
+  config: EmailConfig,
+) => {
+  return sendEmail({
+    apiKey: config.apiKey,
+    defaultReplyTo: config.defaultReplyTo,
+    from: config.from || DEFAULT_FROM,
+    subject: "Reset your Acme password",
+    tags: [
+      { name: "type", value: "password-reset" },
+      ...(username ? [{ name: "username", value: username }] : []),
+    ],
+    template: React.createElement(PasswordResetEmail, {
+      browserInfo,
+      ipAddress,
+      resetUrl,
+      userEmail,
+      username,
+    }),
+    to: userEmail,
+  });
+};
+
+export { sendWelcomeEmail, sendPasswordResetEmail, sendSignUpAttemptEmail };

--- a/packages/transactional/tsconfig.json
+++ b/packages/transactional/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@repo/typescript-config/react-library.json",
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/transactional/tsdown.config.ts
+++ b/packages/transactional/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  clean: true,
+  dts: true,
+  entry: ["src/index.ts"],
+  format: ["esm"],
+});

--- a/packages/transactional/vitest.config.ts
+++ b/packages/transactional/vitest.config.ts
@@ -1,0 +1,3 @@
+import nodeConfig from "@repo/config-vitest/node";
+
+export default nodeConfig;


### PR DESCRIPTION
## Summary

Greenfield `@repo/transactional` package with the same shape as frow-monorepo's, plus rewiring `@repo/auth` to consume it.

**Package structure** (mirrors `frow-monorepo/packages/transactional`):
- `client.ts` — Resend factory
- `utils/send-email.ts` — single + batch send with zod validation; renders both HTML and plain text for deliverability
- `utils/senders.ts` — typed wrappers: `sendWelcomeEmail`, `sendPasswordResetEmail`, `sendSignUpAttemptEmail`
- `styles/theme.ts` — hex tokens + `tailwindConfig` mapping shadcn names (`bg-primary`, `text-muted-foreground`, etc.) so templates use the same vocabulary as the web app
- `components/` — `Button`, `Card`, `Divider`, `AcmeLogo`
- `emails/base-layout.tsx` — header/footer/Tailwind wiring shared by every template
- `emails/{welcome,password-reset,sign-up-attempt}.tsx` — three templates matching the auth flows

**Auth rewire** (`packages/auth/src/server.ts`):
- Drops inline `import { Resend }` per handler + hand-rolled HTML strings
- Each lifecycle hook (`onExistingUserSignUp`, `sendResetPassword`, `sendVerificationEmail`) now calls a typed sender
- `@repo/auth` no longer depends on `resend` directly — it flows through `@repo/transactional`

**Brand asset note**: `AcmeLogo` points at `https://www.acme.com/logo-wordmark.svg`. If that URL isn't publicly hosted yet, the email shows a broken image with `alt="Acme"`. The four SVGs already exist at `apps/web/public/`; just need them hosted.

## Test plan
- [ ] `pnpm install` (to update lockfile + link `@repo/transactional` workspace dep)
- [ ] `pnpm --filter @repo/transactional build` — tsdown produces dist/
- [ ] `pnpm --filter @repo/auth typecheck` — auth still typechecks against new senders
- [ ] `pnpm --filter @repo/auth test` — existing auth config tests still pass (they use no resendApiKey, so the email-handler `? :` branches stay undefined)
- [ ] CI green