### PR TITLE
chore(fallow): drop inline unused-export ignores via entry-point declaration

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -3,7 +3,11 @@
   "workspaces": {
     "packages": ["apps/*", "packages/*"]
   },
-  "entry": ["oxlint.config.ts", "**/prisma.config.ts"],
+  "entry": [
+    "oxlint.config.ts",
+    "**/prisma.config.ts",
+    "packages/transactional/src/emails/**/*.tsx"
+  ],
   "ignorePatterns": ["verify-auth.js", "tests/e2e/setup/auth.setup.ts"],
   "ignoreDependencies": [
     "eslint-plugin-*",

--- a/packages/transactional/src/emails/password-reset.tsx
+++ b/packages/transactional/src/emails/password-reset.tsx
@@ -70,5 +70,4 @@ const PasswordResetEmail = ({
 };
 
 export { PasswordResetEmail };
-// fallow-ignore-next-line unused-export
 export default PasswordResetEmail;

--- a/packages/transactional/src/emails/sign-up-attempt.tsx
+++ b/packages/transactional/src/emails/sign-up-attempt.tsx
@@ -84,5 +84,4 @@ const SignUpAttemptEmail = ({
 };
 
 export { SignUpAttemptEmail };
-// fallow-ignore-next-line unused-export
 export default SignUpAttemptEmail;

--- a/packages/transactional/src/emails/welcome.tsx
+++ b/packages/transactional/src/emails/welcome.tsx
@@ -60,5 +60,4 @@ const WelcomeEmail = ({ userEmail, username, verificationUrl }: WelcomeEmailProp
 };
 
 export { WelcomeEmail };
-// fallow-ignore-next-line unused-export
 export default WelcomeEmail;


### PR DESCRIPTION
## Summary

Email templates have both a **named export** (consumed by `senders.ts` via `React.createElement`) and a **default export** (consumed by react-email's `email dev` preview CLI). Fallow's static analysis can only trace the named export — it flagged each default as `unused-export`, so each template carried `// fallow-ignore-next-line unused-export`.

This PR drops those inline ignores and instead adds `packages/transactional/src/emails/**/*.tsx` to `.fallowrc.json`'s `entry` list. Fallow now treats each template file as reachable from the start, so the default export is "used" by virtue of the file being a root.

## What changed
- `.fallowrc.json`: added `packages/transactional/src/emails/**/*.tsx` to `entry`
- 3 email template files: dropped `// fallow-ignore-next-line unused-export` comment above each `export default ...` line

## Verification
- `pnpm fallow:dead` passes (pre-existing warn-level `@tanstack/react-form` unused-dep finding on apps/web, unrelated)
- `pnpm format`, `pnpm -r lint`, all green

## Test plan
- [ ] CI green