### PR TITLE
chore: drop internal barrel(s), use deep imports

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -3,7 +3,11 @@
   "workspaces": {
     "packages": ["apps/*", "packages/*"]
   },
-  "entry": ["oxlint.config.ts", "**/prisma.config.ts"],
+  "entry": [
+    "oxlint.config.ts",
+    "**/prisma.config.ts",
+    "packages/transactional/src/emails/**/*.tsx"
+  ],
   "ignorePatterns": ["verify-auth.js", "tests/e2e/setup/auth.setup.ts"],
   "ignoreDependencies": [
     "eslint-plugin-*",

--- a/packages/transactional/src/components/index.ts
+++ b/packages/transactional/src/components/index.ts
@@ -1,4 +1,0 @@
-export { AcmeLogo } from "./acme-logo";
-export { Button } from "./button";
-export { Card } from "./card";
-export { Divider } from "./divider";

--- a/packages/transactional/src/emails/base-layout.tsx
+++ b/packages/transactional/src/emails/base-layout.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Body, Container, Head, Html, Link, Preview, Section, Tailwind, Text } from "react-email";
 
-import { AcmeLogo } from "../components";
+import { AcmeLogo } from "../components/acme-logo";
 import { tailwindConfig } from "../styles/theme";
 
 type BaseLayoutProps = {

--- a/packages/transactional/src/emails/password-reset.tsx
+++ b/packages/transactional/src/emails/password-reset.tsx
@@ -70,5 +70,4 @@ const PasswordResetEmail = ({
 };
 
 export { PasswordResetEmail };
-// fallow-ignore-next-line unused-export
 export default PasswordResetEmail;

--- a/packages/transactional/src/emails/password-reset.tsx
+++ b/packages/transactional/src/emails/password-reset.tsx
@@ -1,6 +1,8 @@
 import { Heading, Link, Text } from "react-email";
 
-import { Button, Card, Divider } from "../components";
+import { Button } from "../components/button";
+import { Card } from "../components/card";
+import { Divider } from "../components/divider";
 
 import { BaseLayout } from "./base-layout";
 

--- a/packages/transactional/src/emails/sign-up-attempt.tsx
+++ b/packages/transactional/src/emails/sign-up-attempt.tsx
@@ -1,6 +1,8 @@
 import { Heading, Link, Text } from "react-email";
 
-import { Button, Card, Divider } from "../components";
+import { Button } from "../components/button";
+import { Card } from "../components/card";
+import { Divider } from "../components/divider";
 
 import { BaseLayout } from "./base-layout";
 

--- a/packages/transactional/src/emails/sign-up-attempt.tsx
+++ b/packages/transactional/src/emails/sign-up-attempt.tsx
@@ -84,5 +84,4 @@ const SignUpAttemptEmail = ({
 };
 
 export { SignUpAttemptEmail };
-// fallow-ignore-next-line unused-export
 export default SignUpAttemptEmail;

--- a/packages/transactional/src/emails/welcome.tsx
+++ b/packages/transactional/src/emails/welcome.tsx
@@ -60,5 +60,4 @@ const WelcomeEmail = ({ userEmail, username, verificationUrl }: WelcomeEmailProp
 };
 
 export { WelcomeEmail };
-// fallow-ignore-next-line unused-export
 export default WelcomeEmail;

--- a/packages/transactional/src/emails/welcome.tsx
+++ b/packages/transactional/src/emails/welcome.tsx
@@ -1,6 +1,7 @@
 import { Heading, Link, Text } from "react-email";
 
-import { Button, Divider } from "../components";
+import { Button } from "../components/button";
+import { Divider } from "../components/divider";
 
 import { BaseLayout } from "./base-layout";
 

--- a/packages/transactional/src/index.ts
+++ b/packages/transactional/src/index.ts
@@ -2,7 +2,10 @@
 export { createResendClient } from "./client";
 
 // Components
-export * from "./components";
+export { AcmeLogo } from "./components/acme-logo";
+export { Button } from "./components/button";
+export { Card } from "./components/card";
+export { Divider } from "./components/divider";
 
 // Utilities
 export { sendEmail, sendBatchEmails, previewEmail } from "./utils/send-email";


### PR DESCRIPTION
## Summary

Removes `packages/transactional/src/components/index.ts`, an internal-only barrel that re-exported `Button`, `Card`, `Divider`, and `AcmeLogo` from sibling files. The four email templates that consumed it now import directly from each component file, and the package's public-API barrel (`packages/transactional/src/index.ts`) re-exports from the component files instead of going through the deleted internal barrel — public surface is unchanged.

Why: fallow can't trace `export *` barrels reliably, so internal barrels mask dead-code detection. Deep imports also avoid bundler-side re-export overhead.

## Test plan

- [x] `pnpm format`
- [x] `pnpm -r lint`
- [x] `pnpm -r typecheck`
- [x] `pnpm -r test`
- [x] `pnpm fallow:dead` (the one finding — `@tanstack/react-form` listed under `apps/web` but imported from `packages/auth` — is pre-existing on `main` and unrelated)