### PR TITLE
fix(auth): clear CI env in production rate-limit test

### DIFF
--- a/packages/auth/src/server.test.ts
+++ b/packages/auth/src/server.test.ts
@@ -102,6 +102,10 @@ describe("Auth Server Configuration", () => {
 
   it("should enable rate limiting in production", () => {
     vi.stubEnv("NODE_ENV", "production");
+    // The rateLimit gate is `production && !CI` — GitHub Actions sets
+    // CI=true on the runner, so we must clear it for the production path
+    // to evaluate true under test.
+    vi.stubEnv("CI", "");
     const prodAuth = createAuth({ prisma, secret: "test-secret-minimum-32-characters-long" });
     expect(prodAuth.options.rateLimit?.enabled).toBe(true);
   });


### PR DESCRIPTION
## Summary

The \`rateLimit.enabled\` gate in \`packages/auth/src/server.ts\` is:

\`\`\`ts
enabled: process.env.NODE_ENV === \"production\" && !process.env.CI,
\`\`\`

GitHub Actions sets \`CI=true\` on the runner. The test stubbed \`NODE_ENV=production\` but didn't clear \`CI\`, so the gate evaluated to \`false\` and the assertion failed on every CI run. Test has been red on \`main\` for at least 3 consecutive runs.

## Fix

Stub \`CI=\"\"\` alongside \`NODE_ENV=production\` in the production rate-limit test.

## Why this matters

Blocks all currently-open acme PRs from going green (#62, #63 both fail \`Test\` on this assertion). Unblocks merge.

## Test plan

- [x] \`CI=true pnpm --filter @repo/auth test\` — 26/26 pass