### PR TITLE
chore(e2e): chromium-only browsers in CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,6 +28,8 @@ export default defineConfig({
   fullyParallel: true,
   globalTeardown: "./tests/e2e/teardown/cleanup.ts",
 
+  // CI runs chromium only — chromium is the canonical Playwright signal;
+  // firefox + webkit run locally / nightly.
   projects: [
     { name: "setup", testMatch: /.*\.setup\.ts/ },
     {
@@ -38,22 +40,26 @@ export default defineConfig({
         storageState: "tests/e2e/.auth/user.json",
       },
     },
-    {
-      dependencies: ["setup"],
-      name: "firefox",
-      use: {
-        ...devices["Desktop Firefox"],
-        storageState: "tests/e2e/.auth/user.json",
-      },
-    },
-    {
-      dependencies: ["setup"],
-      name: "webkit",
-      use: {
-        ...devices["Desktop Safari"],
-        storageState: "tests/e2e/.auth/user.json",
-      },
-    },
+    ...(process.env.CI
+      ? []
+      : [
+          {
+            dependencies: ["setup"],
+            name: "firefox",
+            use: {
+              ...devices["Desktop Firefox"],
+              storageState: "tests/e2e/.auth/user.json",
+            },
+          },
+          {
+            dependencies: ["setup"],
+            name: "webkit",
+            use: {
+              ...devices["Desktop Safari"],
+              storageState: "tests/e2e/.auth/user.json",
+            },
+          },
+        ]),
   ],
 
   reporter: process.env.CI ? [["html", { open: "never" }]] : [["list"], ["html"]],


### PR DESCRIPTION
## Summary

Mirror [collabtime#83](https://github.com/unlockers-io/collabtime-monorepo/pull/83) (commit `chore(e2e): chromium-only browsers in CI`). Wrap the firefox + webkit project entries in a `process.env.CI` conditional so CI runs chromium only; both browsers stay configured for local / nightly runs.

## Why

The 3-browser matrix doesn't fit the 30 min job budget once the suite grows. Chromium is the canonical Playwright signal; firefox + webkit catch a vanishing tail of cross-engine bugs and don't justify the CI minutes.

Re-enable multi-browser CI by unsetting `CI` in the workflow env, or run the testbox workflow on demand.

## Diff

`playwright.config.ts` — wrap firefox + webkit project entries in `...(process.env.CI ? [] : [...])`. Chromium + setup project unchanged. Added a comment block above `projects:` documenting the rationale. No reporter/timeout/retries/webServer changes.

## Test plan

- [ ] CI green on chromium
- [ ] Local `pnpm exec playwright test` still runs chromium + firefox + webkit