### PR TITLE
chore(husky): refuse direct commits on main

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,12 @@
+# Refuse direct commits on main: cross-repo work happens via feature branches
+# created by orchestrator/scripts/worktree.sh. Override (emergency only):
+#   ORCHESTRATOR_ALLOW_MAIN_COMMIT=1 git commit ...
+branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+if [ "$branch" = "main" ] && [ "${ORCHESTRATOR_ALLOW_MAIN_COMMIT:-}" != "1" ]; then
+  echo "ERROR: refusing commit on main." >&2
+  echo "Use a feature branch (orchestrator/scripts/worktree.sh <slug>) or" >&2
+  echo "set ORCHESTRATOR_ALLOW_MAIN_COMMIT=1 to override." >&2
+  exit 1
+fi
+
 pnpm lint-staged


### PR DESCRIPTION
## Summary

Phase 3 of orchestrator's [cross-repo-worktrees spec](https://github.com/unlockers-io/orchestrator/blob/main/docs/superpowers/specs/cross-repo-worktrees.md). The pre-commit hook now hard-refuses commits on \`main\`. Override (emergency):

\`\`\`sh
ORCHESTRATOR_ALLOW_MAIN_COMMIT=1 git commit ...
\`\`\`

## Why

Cross-repo work flows through feature branches created by \`orchestrator/scripts/worktree.sh\`. Direct main commits skip code review, branch protection, and CI on the change set — caught hand-rolled commits from agents earlier this session.

## Test plan

- [x] On a feature branch: \`git commit\` runs lint-staged, succeeds.
- [x] On main without override: \`git commit\` exits 1 with the refusal message.
- [x] On main with \`ORCHESTRATOR_ALLOW_MAIN_COMMIT=1\`: commit proceeds.

## Propagation

Acme is the template; collabtime/localcine/frow/easeia get the same hook in follow-up PRs.