### PR TITLE
chore(openlogs): wrap dev scripts so agents can tail logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ logs/
 # agent output
 /agents/
 .fallow/
+
+# openlogs (dev-server log capture for AI agents)
+.openlogs/

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "start": "turbo run start",
-    "dev": "turbo run dev",
+    "dev": "openlogs turbo run dev",
     "lint": "turbo run lint",
     "format": "oxfmt",
     "format:check": "oxfmt --check",


### PR DESCRIPTION
Prefix root `dev`/`dev:*` scripts with `openlogs ` and add `.openlogs/` to .gitignore. AI agents read backend output via `openlogs tail` once the user runs `pnpm dev`; turbo's per-app prefixes work as filters (`openlogs tail web -n 200`).

Per orchestrator standards.md § Openlogs. Verified by scripts/verify-openlogs.sh.