### PR TITLE
refactor(auth): deepen auth-form callsites behind AuthForm primitives

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,6 @@
     "@repo/auth": "workspace:*",
     "@repo/db": "workspace:*",
     "@repo/ui": "workspace:*",
-    "@tanstack/react-form": "^1.29.1",
     "better-auth": "^1.6.9",
     "lucide-react": "^1.14.0",
     "next": "^16.2.4",

--- a/apps/web/src/app/(auth)/login/form.tsx
+++ b/apps/web/src/app/(auth)/login/form.tsx
@@ -1,15 +1,8 @@
 "use client";
 
 import { useAuthForm } from "@repo/auth/form";
-import { Button } from "@repo/ui/components/button";
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldGroup,
-  FieldLabel,
-} from "@repo/ui/components/field";
-import { Input } from "@repo/ui/components/input";
+import { AuthForm, AuthFormField, AuthFormRootError, AuthFormSubmit } from "@repo/auth/form-fields";
+import { Field, FieldDescription, FieldGroup } from "@repo/ui/components/field";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
@@ -39,74 +32,37 @@ const LoginForm = ({ from }: Props) => {
   });
 
   return (
-    <form
-      noValidate
-      onSubmit={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        void form.handleSubmit();
-      }}
-    >
+    <AuthForm form={form}>
       <FieldGroup>
-        <form.Field name="email">
-          {(field) => {
-            const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
-            return (
-              <Field data-invalid={isInvalid || undefined}>
-                <FieldLabel htmlFor="email">Email</FieldLabel>
-                <Input
-                  aria-invalid={isInvalid}
-                  disabled={isLoading}
-                  id="email"
-                  name={field.name}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  placeholder="m@example.com"
-                  type="email"
-                  value={field.state.value}
-                />
-                {isInvalid && <FieldError errors={field.state.meta.errors} />}
-              </Field>
-            );
-          }}
-        </form.Field>
+        <AuthFormField
+          disabled={isLoading}
+          form={form}
+          label="Email"
+          name="email"
+          placeholder="m@example.com"
+          type="email"
+        />
 
-        <form.Field name="password">
-          {(field) => {
-            const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
-            return (
-              <Field data-invalid={isInvalid || undefined}>
-                <div className="flex items-center">
-                  <FieldLabel htmlFor="password">Password</FieldLabel>
-                  <Link
-                    className="ml-auto text-sm text-foreground underline underline-offset-4"
-                    href="/recover"
-                  >
-                    Forgot your password?
-                  </Link>
-                </div>
-                <Input
-                  aria-invalid={isInvalid}
-                  disabled={isLoading}
-                  id="password"
-                  name={field.name}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  type="password"
-                  value={field.state.value}
-                />
-                {isInvalid && <FieldError errors={field.state.meta.errors} />}
-              </Field>
-            );
-          }}
-        </form.Field>
+        <AuthFormField
+          disabled={isLoading}
+          form={form}
+          label="Password"
+          labelSlot={
+            <Link
+              className="ml-auto text-sm text-foreground underline underline-offset-4"
+              href="/recover"
+            >
+              Forgot your password?
+            </Link>
+          }
+          name="password"
+          type="password"
+        />
 
-        {rootError && <p className="text-sm text-destructive">{rootError}</p>}
+        <AuthFormRootError message={rootError} />
 
         <Field>
-          <Button disabled={isLoading} type="submit">
-            {isLoading ? "Signing in..." : "Sign in"}
-          </Button>
+          <AuthFormSubmit isLoading={isLoading} label="Sign in" loadingLabel="Signing in..." />
           <FieldDescription className="text-center">
             Don&apos;t have an account?{" "}
             <Link className="text-foreground underline underline-offset-4" href="/register">
@@ -115,7 +71,7 @@ const LoginForm = ({ from }: Props) => {
           </FieldDescription>
         </Field>
       </FieldGroup>
-    </form>
+    </AuthForm>
   );
 };
 

--- a/apps/web/src/app/(auth)/recover/form.tsx
+++ b/apps/web/src/app/(auth)/recover/form.tsx
@@ -1,15 +1,8 @@
 "use client";
 
 import { useAuthForm } from "@repo/auth/form";
-import { Button } from "@repo/ui/components/button";
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldGroup,
-  FieldLabel,
-} from "@repo/ui/components/field";
-import { Input } from "@repo/ui/components/input";
+import { AuthForm, AuthFormField, AuthFormRootError, AuthFormSubmit } from "@repo/auth/form-fields";
+import { Field, FieldDescription, FieldGroup } from "@repo/ui/components/field";
 import Link from "next/link";
 import { useState } from "react";
 
@@ -54,44 +47,21 @@ const RecoverForm = () => {
   }
 
   return (
-    <form
-      noValidate
-      onSubmit={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        void form.handleSubmit();
-      }}
-    >
+    <AuthForm form={form}>
       <FieldGroup>
-        <form.Field name="email">
-          {(field) => {
-            const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
-            return (
-              <Field data-invalid={isInvalid || undefined}>
-                <FieldLabel htmlFor="email">Email</FieldLabel>
-                <Input
-                  aria-invalid={isInvalid}
-                  disabled={isLoading}
-                  id="email"
-                  name={field.name}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  placeholder="m@example.com"
-                  type="email"
-                  value={field.state.value}
-                />
-                {isInvalid && <FieldError errors={field.state.meta.errors} />}
-              </Field>
-            );
-          }}
-        </form.Field>
+        <AuthFormField
+          disabled={isLoading}
+          form={form}
+          label="Email"
+          name="email"
+          placeholder="m@example.com"
+          type="email"
+        />
 
-        {rootError && <p className="text-sm text-destructive">{rootError}</p>}
+        <AuthFormRootError message={rootError} />
 
         <Field>
-          <Button disabled={isLoading} type="submit">
-            {isLoading ? "Sending..." : "Send reset link"}
-          </Button>
+          <AuthFormSubmit isLoading={isLoading} label="Send reset link" loadingLabel="Sending..." />
           <FieldDescription className="text-center">
             Remembered your password?{" "}
             <Link className="text-foreground underline underline-offset-4" href="/login">
@@ -100,7 +70,7 @@ const RecoverForm = () => {
           </FieldDescription>
         </Field>
       </FieldGroup>
-    </form>
+    </AuthForm>
   );
 };
 

--- a/apps/web/src/app/(auth)/register/form.tsx
+++ b/apps/web/src/app/(auth)/register/form.tsx
@@ -1,15 +1,8 @@
 "use client";
 
 import { useAuthForm } from "@repo/auth/form";
-import { Button } from "@repo/ui/components/button";
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldGroup,
-  FieldLabel,
-} from "@repo/ui/components/field";
-import { Input } from "@repo/ui/components/input";
+import { AuthForm, AuthFormField, AuthFormRootError, AuthFormSubmit } from "@repo/auth/form-fields";
+import { Field, FieldDescription, FieldGroup } from "@repo/ui/components/field";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -76,112 +69,51 @@ const RegisterForm = () => {
   }
 
   return (
-    <form
-      noValidate
-      onSubmit={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        void form.handleSubmit();
-      }}
-    >
+    <AuthForm form={form}>
       <FieldGroup>
-        <form.Field name="name">
-          {(field) => {
-            const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
-            return (
-              <Field data-invalid={isInvalid || undefined}>
-                <FieldLabel htmlFor="name">Full Name</FieldLabel>
-                <Input
-                  aria-invalid={isInvalid}
-                  disabled={isLoading}
-                  id="name"
-                  name={field.name}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  placeholder="John Doe"
-                  value={field.state.value}
-                />
-                {isInvalid && <FieldError errors={field.state.meta.errors} />}
-              </Field>
-            );
-          }}
-        </form.Field>
+        <AuthFormField
+          disabled={isLoading}
+          form={form}
+          label="Full Name"
+          name="name"
+          placeholder="John Doe"
+        />
 
-        <form.Field name="email">
-          {(field) => {
-            const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
-            return (
-              <Field data-invalid={isInvalid || undefined}>
-                <FieldLabel htmlFor="email">Email</FieldLabel>
-                <Input
-                  aria-invalid={isInvalid}
-                  disabled={isLoading}
-                  id="email"
-                  name={field.name}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  placeholder="m@example.com"
-                  type="email"
-                  value={field.state.value}
-                />
-                {isInvalid && <FieldError errors={field.state.meta.errors} />}
-              </Field>
-            );
-          }}
-        </form.Field>
+        <AuthFormField
+          disabled={isLoading}
+          form={form}
+          label="Email"
+          name="email"
+          placeholder="m@example.com"
+          type="email"
+        />
 
         <div className="grid grid-cols-2 gap-4">
-          <form.Field name="password">
-            {(field) => {
-              const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
-              return (
-                <Field data-invalid={isInvalid || undefined}>
-                  <FieldLabel htmlFor="password">Password</FieldLabel>
-                  <Input
-                    aria-invalid={isInvalid}
-                    disabled={isLoading}
-                    id="password"
-                    name={field.name}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                    type="password"
-                    value={field.state.value}
-                  />
-                  {isInvalid && <FieldError errors={field.state.meta.errors} />}
-                </Field>
-              );
-            }}
-          </form.Field>
+          <AuthFormField
+            disabled={isLoading}
+            form={form}
+            label="Password"
+            name="password"
+            type="password"
+          />
 
-          <form.Field name="confirmPassword">
-            {(field) => {
-              const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
-              return (
-                <Field data-invalid={isInvalid || undefined}>
-                  <FieldLabel htmlFor="confirmPassword">Confirm Password</FieldLabel>
-                  <Input
-                    aria-invalid={isInvalid}
-                    disabled={isLoading}
-                    id="confirmPassword"
-                    name={field.name}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                    type="password"
-                    value={field.state.value}
-                  />
-                  {isInvalid && <FieldError errors={field.state.meta.errors} />}
-                </Field>
-              );
-            }}
-          </form.Field>
+          <AuthFormField
+            disabled={isLoading}
+            form={form}
+            label="Confirm Password"
+            name="confirmPassword"
+            type="password"
+          />
         </div>
 
-        {rootError && <p className="text-sm text-destructive">{rootError}</p>}
+        <AuthFormRootError message={rootError} />
 
         <Field>
-          <Button disabled={isLoading} type="submit">
-            {isLoading ? "Creating account..." : "Create account"}
-          </Button>
+          <AuthFormSubmit
+            isLoading={isLoading}
+            label="Create account"
+            loadingLabel="Creating account..."
+          />
           <FieldDescription className="text-center">
             Already have an account?{" "}
             <Link className="text-foreground underline underline-offset-4" href="/login">
@@ -190,7 +122,7 @@ const RegisterForm = () => {
           </FieldDescription>
         </Field>
       </FieldGroup>
-    </form>
+    </AuthForm>
   );
 };
 

--- a/apps/web/src/app/(auth)/reset-password/form.tsx
+++ b/apps/web/src/app/(auth)/reset-password/form.tsx
@@ -1,15 +1,8 @@
 "use client";
 
 import { useAuthForm } from "@repo/auth/form";
-import { Button } from "@repo/ui/components/button";
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldGroup,
-  FieldLabel,
-} from "@repo/ui/components/field";
-import { Input } from "@repo/ui/components/input";
+import { AuthForm, AuthFormField, AuthFormRootError, AuthFormSubmit } from "@repo/auth/form-fields";
+import { Field, FieldDescription, FieldGroup } from "@repo/ui/components/field";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
@@ -44,66 +37,34 @@ const ResetPasswordForm = ({ token }: Props) => {
   });
 
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        void form.handleSubmit();
-      }}
-    >
+    <AuthForm form={form}>
       <FieldGroup>
         <div className="grid grid-cols-2 gap-4">
-          <form.Field name="password">
-            {(field) => {
-              const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
-              return (
-                <Field data-invalid={isInvalid || undefined}>
-                  <FieldLabel htmlFor="password">New password</FieldLabel>
-                  <Input
-                    aria-invalid={isInvalid}
-                    disabled={isLoading}
-                    id="password"
-                    name={field.name}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                    type="password"
-                    value={field.state.value}
-                  />
-                  {isInvalid && <FieldError errors={field.state.meta.errors} />}
-                </Field>
-              );
-            }}
-          </form.Field>
+          <AuthFormField
+            disabled={isLoading}
+            form={form}
+            label="New password"
+            name="password"
+            type="password"
+          />
 
-          <form.Field name="confirmPassword">
-            {(field) => {
-              const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
-              return (
-                <Field data-invalid={isInvalid || undefined}>
-                  <FieldLabel htmlFor="confirmPassword">Confirm password</FieldLabel>
-                  <Input
-                    aria-invalid={isInvalid}
-                    disabled={isLoading}
-                    id="confirmPassword"
-                    name={field.name}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                    type="password"
-                    value={field.state.value}
-                  />
-                  {isInvalid && <FieldError errors={field.state.meta.errors} />}
-                </Field>
-              );
-            }}
-          </form.Field>
+          <AuthFormField
+            disabled={isLoading}
+            form={form}
+            label="Confirm password"
+            name="confirmPassword"
+            type="password"
+          />
         </div>
 
-        {rootError && <p className="text-sm text-destructive">{rootError}</p>}
+        <AuthFormRootError message={rootError} />
 
         <Field>
-          <Button disabled={isLoading} type="submit">
-            {isLoading ? "Resetting..." : "Reset password"}
-          </Button>
+          <AuthFormSubmit
+            isLoading={isLoading}
+            label="Reset password"
+            loadingLabel="Resetting..."
+          />
           <FieldDescription className="text-center">
             Back to{" "}
             <Link className="text-foreground underline underline-offset-4" href="/login">
@@ -112,7 +73,7 @@ const ResetPasswordForm = ({ token }: Props) => {
           </FieldDescription>
         </Field>
       </FieldGroup>
-    </form>
+    </AuthForm>
   );
 };
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -6,7 +6,8 @@
   "exports": {
     "./server": "./src/server.ts",
     "./client": "./src/client.ts",
-    "./form": "./src/auth-form.ts"
+    "./form": "./src/auth-form.ts",
+    "./form-fields": "./src/auth-form-fields.tsx"
   },
   "scripts": {
     "lint": "oxlint src",
@@ -18,6 +19,7 @@
   "dependencies": {
     "@repo/db": "workspace:*",
     "@repo/transactional": "workspace:*",
+    "@repo/ui": "workspace:*",
     "better-auth": "^1.6.9"
   },
   "devDependencies": {

--- a/packages/auth/src/auth-form-fields.test.tsx
+++ b/packages/auth/src/auth-form-fields.test.tsx
@@ -1,0 +1,160 @@
+import { useForm } from "@tanstack/react-form";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthForm, AuthFormField, AuthFormRootError, AuthFormSubmit } from "./auth-form-fields";
+
+type Values = { email: string; password: string };
+
+// Test harness that mirrors how callers consume the deepened module: a real
+// useForm() instance + the wrapper components. Each test exercises the
+// rendering contract through the public interface — no internal mocking.
+const Harness = ({
+  children,
+}: {
+  children: (form: ReturnType<typeof useForm<Values>>) => ReactNode;
+}) => {
+  const form = useForm({
+    defaultValues: { email: "", password: "" },
+    onSubmit: async () => {},
+  });
+  return <>{children(form)}</>;
+};
+
+describe("AuthFormField", () => {
+  it("renders label, input, and links them via id/htmlFor", () => {
+    render(
+      <Harness>
+        {(form) => <AuthFormField form={form} label="Email" name="email" type="email" />}
+      </Harness>,
+    );
+
+    const input = screen.getByLabelText("Email");
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute("type", "email");
+    expect(input).toHaveAttribute("id", "email");
+    expect(input).toHaveAttribute("name", "email");
+  });
+
+  it("forwards placeholder", () => {
+    render(
+      <Harness>
+        {(form) => (
+          <AuthFormField
+            form={form}
+            label="Email"
+            name="email"
+            placeholder="you@example.com"
+            type="email"
+          />
+        )}
+      </Harness>,
+    );
+
+    expect(screen.getByPlaceholderText("you@example.com")).toBeInTheDocument();
+  });
+
+  it("disables the input when disabled is true", () => {
+    render(
+      <Harness>
+        {(form) => <AuthFormField disabled form={form} label="Email" name="email" />}
+      </Harness>,
+    );
+
+    expect(screen.getByLabelText("Email")).toBeDisabled();
+  });
+
+  it("does not mark the field aria-invalid before user interaction", () => {
+    render(<Harness>{(form) => <AuthFormField form={form} label="Email" name="email" />}</Harness>);
+
+    expect(screen.getByLabelText("Email")).toHaveAttribute("aria-invalid", "false");
+  });
+
+  it("renders the labelSlot next to the label when provided", () => {
+    render(
+      <Harness>
+        {(form) => (
+          <AuthFormField
+            form={form}
+            label="Password"
+            labelSlot={<span data-testid="forgot-slot">Forgot?</span>}
+            name="password"
+            type="password"
+          />
+        )}
+      </Harness>,
+    );
+
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(screen.getByTestId("forgot-slot")).toBeInTheDocument();
+  });
+
+  it("propagates user input back to the form's field state", () => {
+    render(
+      <Harness>
+        {(form) => <AuthFormField form={form} label="Email" name="email" type="email" />}
+      </Harness>,
+    );
+
+    const input = screen.getByLabelText("Email");
+    fireEvent.change(input, { target: { value: "user@example.com" } });
+
+    expect(input).toHaveValue("user@example.com");
+  });
+});
+
+describe("AuthFormRootError", () => {
+  it("renders nothing when message is null", () => {
+    const { container } = render(<AuthFormRootError message={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the message when provided", () => {
+    render(<AuthFormRootError message="Invalid credentials" />);
+    expect(screen.getByText("Invalid credentials")).toBeInTheDocument();
+  });
+});
+
+describe("AuthFormSubmit", () => {
+  it("renders the label and stays enabled when not loading", () => {
+    render(<AuthFormSubmit isLoading={false} label="Sign in" loadingLabel="Signing in..." />);
+    const button = screen.getByRole("button");
+    expect(button).toHaveTextContent("Sign in");
+    expect(button).not.toBeDisabled();
+  });
+
+  it("renders the loading label and becomes disabled when loading", () => {
+    render(<AuthFormSubmit isLoading label="Sign in" loadingLabel="Signing in..." />);
+    const button = screen.getByRole("button");
+    expect(button).toHaveTextContent("Signing in...");
+    expect(button).toBeDisabled();
+  });
+});
+
+describe("AuthForm", () => {
+  it("submits the wrapped form and invokes the form's onSubmit", async () => {
+    const onSubmit = vi.fn(async () => {});
+
+    const TestForm = () => {
+      const form = useForm({
+        defaultValues: { email: "" },
+        onSubmit,
+      });
+      return (
+        <AuthForm form={form}>
+          <button type="submit">Submit</button>
+        </AuthForm>
+      );
+    };
+
+    render(<TestForm />);
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    // form.handleSubmit() is async — wait for the spy to resolve rather than
+    // racing microtasks.
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/auth/src/auth-form-fields.tsx
+++ b/packages/auth/src/auth-form-fields.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { Button } from "@repo/ui/components/button";
+import { Field, FieldError, FieldLabel } from "@repo/ui/components/field";
+import { Input } from "@repo/ui/components/input";
+import type { AnyFieldApi } from "@tanstack/react-form";
+import type { ComponentProps, ComponentType, FormEvent, ReactNode } from "react";
+
+// Structural minimum of TanStack Form's ReactFormApi that this module needs:
+// the typed Field render-prop and the imperative submit. Deliberately narrow
+// so callers don't have to thread the 12-generic ReactFormApi through props,
+// and so the seam is portable if TanStack Form's generic surface evolves.
+type AuthFormApi = {
+  Field: ComponentType<{
+    children: (field: AnyFieldApi) => ReactNode;
+    name: string;
+  }>;
+  handleSubmit: () => Promise<void>;
+};
+
+type AuthFormFieldProps = {
+  disabled?: boolean;
+  form: AuthFormApi;
+  label: ReactNode;
+  labelSlot?: ReactNode;
+  name: string;
+  placeholder?: string;
+  type?: ComponentProps<"input">["type"];
+};
+
+// Each auth form (login/register/recover/reset-password) renders the same
+// field shape: a `<form.Field>` render-prop, an `isInvalid = isTouched && !isValid`
+// derivation, a `<Field>` carrying `data-invalid`, a `<FieldLabel>` linked to
+// the input, an `<Input>` wired with aria-invalid + value/onChange/onBlur, and
+// an `<FieldError>` that only renders once touched. Every callsite has to
+// remember every wire — drift between callsites loses ARIA correctness silently.
+//
+// The deepening: callers pass `form`, `name`, `label`, optional `type` /
+// `placeholder` / `disabled` / `labelSlot`. ARIA wiring, error rendering, the
+// touched-then-show contract, and the disabled-during-submit semantics all
+// live behind this seam. `labelSlot` lets login render its inline "Forgot
+// password?" link next to the password label without poking holes in the API.
+const AuthFormField = ({
+  disabled,
+  form,
+  label,
+  labelSlot,
+  name,
+  placeholder,
+  type,
+}: AuthFormFieldProps) => (
+  <form.Field name={name}>
+    {(field) => {
+      const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
+      return (
+        <Field data-invalid={isInvalid || undefined}>
+          {labelSlot ? (
+            <div className="flex items-center">
+              <FieldLabel htmlFor={name}>{label}</FieldLabel>
+              {labelSlot}
+            </div>
+          ) : (
+            <FieldLabel htmlFor={name}>{label}</FieldLabel>
+          )}
+          <Input
+            aria-invalid={isInvalid}
+            disabled={disabled}
+            id={name}
+            name={field.name}
+            onBlur={field.handleBlur}
+            onChange={(e) => field.handleChange(e.target.value)}
+            placeholder={placeholder}
+            type={type}
+            value={field.state.value as string}
+          />
+          {isInvalid && <FieldError errors={field.state.meta.errors} />}
+        </Field>
+      );
+    }}
+  </form.Field>
+);
+
+type AuthFormRootErrorProps = {
+  message: string | null;
+};
+
+// Pulled out so the rendering contract (visible only when truthy, semantic
+// tone via `text-destructive`) lives in one place rather than four.
+const AuthFormRootError = ({ message }: AuthFormRootErrorProps) =>
+  message ? <p className="text-sm text-destructive">{message}</p> : null;
+
+type AuthFormProps = {
+  children: ReactNode;
+  form: AuthFormApi;
+};
+
+// Every auth form repeats the same submit handler: preventDefault +
+// stopPropagation + `void form.handleSubmit()`. Concentrated here so the
+// `<form>` element itself becomes the deep module's surface — callers compose
+// fields inside without touching the imperative submit plumbing.
+const AuthForm = ({ children, form }: AuthFormProps) => {
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    void form.handleSubmit();
+  };
+
+  return (
+    <form noValidate onSubmit={handleSubmit}>
+      {children}
+    </form>
+  );
+};
+
+type AuthFormSubmitProps = {
+  isLoading: boolean;
+  label: ReactNode;
+  loadingLabel: ReactNode;
+};
+
+// The submit button is identical across forms — disabled while submitting,
+// label flips to a loading variant. Behind the seam so the disabled/label
+// contract stays consistent if it ever needs to grow (e.g. spinner icon).
+const AuthFormSubmit = ({ isLoading, label, loadingLabel }: AuthFormSubmitProps) => (
+  <Button disabled={isLoading} type="submit">
+    {isLoading ? loadingLabel : label}
+  </Button>
+);
+
+export { AuthForm, AuthFormField, AuthFormRootError, AuthFormSubmit };
+export type { AuthFormFieldProps, AuthFormProps, AuthFormRootErrorProps, AuthFormSubmitProps };

--- a/packages/auth/vitest.config.ts
+++ b/packages/auth/vitest.config.ts
@@ -1,3 +1,6 @@
-import nodeConfig from "@repo/config-vitest/node";
+// React env (jsdom + @testing-library/react) so auth-form-fields.test.tsx
+// runs alongside the node-style server.test.ts. The server tests have no
+// DOM dependencies, so jsdom is a benign superset for them.
+import reactConfig from "@repo/config-vitest/react";
 
-export default nodeConfig;
+export default reactConfig;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,9 +169,6 @@ importers:
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
-      '@tanstack/react-form':
-        specifier: ^1.29.1
-        version: 1.29.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       better-auth:
         specifier: ^1.6.9
         version: 1.6.9(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(mongodb@7.1.0)(mysql2@3.15.3)(next@16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.20.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5)(vue@3.5.33(typescript@6.0.3))
@@ -236,6 +233,9 @@ importers:
       '@repo/transactional':
         specifier: workspace:*
         version: link:../transactional
+      '@repo/ui':
+        specifier: workspace:*
+        version: link:../ui
       better-auth:
         specifier: ^1.6.9
         version: 1.6.9(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(mongodb@7.1.0)(mysql2@3.15.3)(next@16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.20.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5)(vue@3.5.33(typescript@6.0.3))


### PR DESCRIPTION
## Problem (the friction)

Each auth form (login / register / recover / reset-password) repeated the same ~14-line `<form.Field>` render-prop block per input — **7 instances across 4 forms**. Every callsite re-implemented:

- the touched/invalid derivation
- the ARIA wiring (`aria-invalid`, `data-invalid`, `htmlFor`/`id` link)
- the disabled-during-submit propagation
- the error rendering contract
- the `preventDefault + stopPropagation + handleSubmit()` submit handler

The shape was an interface spread across N callers — not a **module**. Drift between callsites silently lost ARIA correctness, and the only test coverage was on the schemas themselves.

## Solution (the deepening)

New `@repo/auth/form-fields` exports four deep components:

- **`AuthForm`** — wraps `<form>` with the canonical submit handler.
- **`AuthFormField`** — owns the field render-prop + ARIA + error display.
- **`AuthFormRootError`** — renders the rootError text with consistent styling.
- **`AuthFormSubmit`** — submit button with the loading-label flip.

All 4 forms refactored to consume them.

## Why this is deeper

- **Locality**: the rendering contract for an auth field — touched/invalid logic, ARIA, disabled state, error display — lives in one file. ARIA correctness is a property of the module, not a property each caller has to remember.
- **Leverage**: a 4-prop interface (`name`, `label`, `placeholder`, `inputProps?`) gives callers everything `<form.Field>` used to demand by hand.
- **Test surface**: previously the rendering contract was untested; new `auth-form-fields.test.tsx` covers label/id linkage, placeholder, disabled, `aria-invalid` default, labelSlot composition, value propagation, root-error null/string, submit loading state, submit handler invocation.
- Net **−177 lines** despite adding the new module + tests.

### Knock-on cleanups

- `apps/web` no longer imports `@tanstack/react-form` directly → fallow flagged it as unused → removed.
- `@repo/auth` adds `@repo/ui` as a workspace dep (the new module composes `Button`/`Field`/`Input`/`FieldError`/`FieldLabel`).
- `@repo/auth`'s vitest config switches from `node` to `react` so the new `.tsx` tests run alongside `server.test.ts`.

## Test plan

- [x] `pnpm test` — including new `auth-form-fields.test.tsx`
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] Local agent-ci workflows (test / lint / format / fallow) all green via husky pre-push