### PR TITLE
chore: drop runtime portless lookups; rely on env from conductor setup

### DIFF
--- a/apps/landing/src/lib/urls.ts
+++ b/apps/landing/src/lib/urls.ts
@@ -1,7 +1,8 @@
 // The landing app is served from a different host than the web app, so links
 // to /login, /register, etc. must be absolute URLs pointing at the web origin.
-// `NEXT_PUBLIC_WEB_APP_URL` is read at build time; default matches the local
-// portless dev convention.
+// `NEXT_PUBLIC_WEB_APP_URL` is read at build time from the dev `.env.local`
+// (populated by the conductor setup script) in dev, and from the deploy env
+// in prod/CI. Fallback matches the canonical local web host.
 const WEB_APP_URL = process.env.NEXT_PUBLIC_WEB_APP_URL ?? "https://acme.web.localhost";
 
 const webAppUrl = (path: string) => {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
     "A modern, secure authentication platform built with Better Auth and Next.js. Fast, reliable, and developer-friendly.",
   keywords: ["authentication", "security", "next.js", "better-auth", "login", "registration"],
   // Resolves Open Graph / Twitter card image URLs against this base. Falls
-  // back to the local portless web origin when BETTER_AUTH_URL isn't set.
+  // back to the canonical local web origin when BETTER_AUTH_URL isn't set.
   metadataBase: new URL(process.env.BETTER_AUTH_URL ?? "https://acme.web.localhost"),
   publisher: "Acme",
   title: {

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -1,5 +1,3 @@
-import { execFileSync } from "node:child_process";
-
 import type { PrismaClient } from "@repo/db";
 import {
   sendPasswordResetEmail,
@@ -12,26 +10,7 @@ import { bearer } from "better-auth/plugins/bearer";
 import { username } from "better-auth/plugins/username";
 import type { BetterAuthPlugin } from "better-auth/types";
 
-const getPortlessUrl = (name: string) => {
-  if (process.env.CI) {
-    return undefined;
-  }
-  try {
-    return execFileSync("portless", ["get", name], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    return undefined;
-  }
-};
-
-const resolveBaseUrl = (): string => {
-  if (process.env.NODE_ENV === "production" || process.env.CI) {
-    return process.env.BETTER_AUTH_URL || "http://localhost:4000";
-  }
-  return getPortlessUrl("acme.api") ?? process.env.BETTER_AUTH_URL ?? "http://localhost:4000";
-};
+const resolveBaseUrl = (): string => process.env.BETTER_AUTH_URL || "http://localhost:4000";
 
 const defaultTrustedOrigins = () => {
   // Both `localhost` and `127.0.0.1` are loopback but Better Auth's origin
@@ -39,7 +18,7 @@ const defaultTrustedOrigins = () => {
   // (Node ≥18 resolves `localhost` to `::1` first; servers bind to 0.0.0.0/IPv4
   // and undici doesn't fall back), so omitting the IPv4 form rejects every
   // request from those tests with `[Better Auth]: Invalid origin`.
-  const origins = [
+  return [
     "http://localhost:3000",
     "http://localhost:3001",
     "http://localhost:4000",
@@ -47,16 +26,6 @@ const defaultTrustedOrigins = () => {
     "http://127.0.0.1:3001",
     "http://127.0.0.1:4000",
   ];
-
-  const portlessNames = ["acme.web", "acme.landing", "acme.api"];
-  for (const name of portlessNames) {
-    const url = getPortlessUrl(name);
-    if (url) {
-      origins.push(url);
-    }
-  }
-
-  return origins;
 };
 
 type AuthConfig = {
@@ -207,7 +176,10 @@ export const createAuth = (config: AuthConfig) => {
       storeSessionInDatabase: true,
       updateAge: 60 * 60 * 24, // Update session if older than 1 day
     },
-    trustedOrigins: process.env.TRUSTED_ORIGINS?.split(",") || defaultTrustedOrigins(),
+    trustedOrigins:
+      process.env.TRUSTED_ORIGINS?.split(",")
+        .map((origin) => origin.trim())
+        .filter(Boolean) ?? defaultTrustedOrigins(),
     user: {
       additionalFields: {
         displayName: {


### PR DESCRIPTION
## Summary

Dev URL resolution used to shell out to `portless get <name>` at runtime via `execFileSync` in `@repo/auth`. With the conductor setup script now pre-populating `.env.local`, app code can just read `process.env.X` directly — no subprocess calls, no `node:child_process` dependency.

- `packages/auth/src/server.ts`: removed `getPortlessUrl()` helper, the `portlessNames` loop in `defaultTrustedOrigins`, the dev-only branch in `resolveBaseUrl`, and the now-unused `node:child_process` import. Base URL collapses to `process.env.BETTER_AUTH_URL || "http://localhost:4000"` everywhere. `trustedOrigins` still env-driven (`TRUSTED_ORIGINS`, comma-separated), now trims entries and filters empties so a stray comma or blank var doesn't inject `""` as an origin.
- `apps/landing/src/lib/urls.ts`: comment updated to point at `.env.local` (conductor setup) as the source of truth instead of "portless dev convention".
- `apps/web/src/app/layout.tsx`: "local portless web origin" comment retitled to "canonical local web origin".

CORS_ORIGINS was already env-driven in `apps/api` — no changes needed there.

## Behavior

- Prod / CI: identical (already read from env).
- Dev: `BETTER_AUTH_URL` and `TRUSTED_ORIGINS` now come from `.env.local` written by the conductor setup script. Hardcoded localhost fallbacks remain for the empty-env case.

## Test plan

- [x] `pnpm typecheck` clean (8/8 tasks)
- [x] `pnpm lint` clean (0 warnings, 0 errors)
- [x] `pnpm --filter @repo/auth test` — 26/26 pass (covers `TRUSTED_ORIGINS` env parsing and default origins)
- [x] Final grep: `grep -rn "portless" apps/*/src packages/*/src` returns zero hits
- [ ] Manual: run `pnpm dev` with `.env.local` populated by conductor setup; verify auth flow works end-to-end