### PR TITLE
refactor(auth): trusted-origins from env concats with loopback defaults

### DIFF
--- a/packages/auth/src/server.test.ts
+++ b/packages/auth/src/server.test.ts
@@ -110,14 +110,15 @@ describe("Auth Server Configuration", () => {
     expect(prodAuth.options.rateLimit?.enabled).toBe(true);
   });
 
-  it("should parse TRUSTED_ORIGINS env var as comma-separated list", () => {
+  it("should concat TRUSTED_ORIGINS env values with loopback defaults", () => {
     vi.stubEnv("TRUSTED_ORIGINS", "https://app.acme.com,https://api.acme.com");
 
     const envAuth = createAuth({ prisma, secret: "test-secret-minimum-32-characters-long" });
-    expect(envAuth.options.trustedOrigins).toEqual([
-      "https://app.acme.com",
-      "https://api.acme.com",
-    ]);
+    const trusted = envAuth.options.trustedOrigins;
+    expect(trusted).toContain("https://app.acme.com"); // env value
+    expect(trusted).toContain("https://api.acme.com"); // env value
+    expect(trusted).toContain("http://localhost:3000"); // loopback default
+    expect(trusted).toContain("http://127.0.0.1:3000"); // loopback default
   });
 
   it("should always define reset password handler (no-op when resendApiKey is absent)", () => {

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -18,7 +18,7 @@ const defaultTrustedOrigins = () => {
   // (Node ≥18 resolves `localhost` to `::1` first; servers bind to 0.0.0.0/IPv4
   // and undici doesn't fall back), so omitting the IPv4 form rejects every
   // request from those tests with `[Better Auth]: Invalid origin`.
-  return [
+  const origins = [
     "http://localhost:3000",
     "http://localhost:3001",
     "http://localhost:4000",
@@ -26,6 +26,15 @@ const defaultTrustedOrigins = () => {
     "http://127.0.0.1:3001",
     "http://127.0.0.1:4000",
   ];
+  // CONCAT, don't REPLACE: env values augment the loopback defaults so
+  // localhost stays trusted alongside portless/prod URLs (the setup script
+  // writes portless hosts to TRUSTED_ORIGINS). Trusting loopback in prod is
+  // harmless — the load balancer terminates before requests reach the app.
+  const extra =
+    process.env.TRUSTED_ORIGINS?.split(",")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0) ?? [];
+  return [...origins, ...extra];
 };
 
 type AuthConfig = {
@@ -176,10 +185,7 @@ export const createAuth = (config: AuthConfig) => {
       storeSessionInDatabase: true,
       updateAge: 60 * 60 * 24, // Update session if older than 1 day
     },
-    trustedOrigins:
-      process.env.TRUSTED_ORIGINS?.split(",")
-        .map((origin) => origin.trim())
-        .filter(Boolean) ?? defaultTrustedOrigins(),
+    trustedOrigins: defaultTrustedOrigins(),
     user: {
       additionalFields: {
         displayName: {


### PR DESCRIPTION
## Summary

Flip `TRUSTED_ORIGINS` semantics in `packages/auth/src/server.ts` from REPLACE to CONCAT so env values augment the hardcoded loopback list instead of replacing it.

The helper's own comment already explains why IPv4 loopback must always be present for CI playwright tests — REPLACE silently broke that guarantee whenever `TRUSTED_ORIGINS` was set. Trusting loopback in prod is harmless (load balancer terminates before requests reach the app), and the setup script writes portless URLs to `TRUSTED_ORIGINS` — CONCAT keeps localhost trusted alongside them.

Standardizes the shape across the fleet — matches what easeia already ships.

## Changes

- `packages/auth/src/server.ts` — `defaultTrustedOrigins()` now returns `[...loopback, ...env]`; the `trustedOrigins` field always delegates to it.
- `packages/auth/src/server.test.ts` — env-parsing test now asserts CONCAT (uses `toContain` for resilience).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter @repo/auth test` (26 passed)