### PR TITLE
chore(dev): consolidate dev script + capture WORKTREE_NAME from $PWD

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsdown",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
-    "dev": "portless run --name acme.api tsdown --watch --on-success \"node dist/index.mjs\"",
+    "dev": "portless run --name ${WORKTREE_NAME:+${WORKTREE_NAME}.}acme.api tsdown --watch --on-success \"node dist/index.mjs\"",
     "lint": "oxlint src",
     "typecheck": "tsc --noEmit",
     "start": "node dist/index.mjs",

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "portless run --name acme.landing next dev",
+    "dev": "portless run --name ${WORKTREE_NAME:+${WORKTREE_NAME}.}acme.landing next dev",
     "build": "next build",
     "start": "next start",
     "lint": "oxlint src",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "portless run --name acme.web next dev",
+    "dev": "portless run --name ${WORKTREE_NAME:+${WORKTREE_NAME}.}acme.web next dev",
     "build": "next build",
     "start": "next start",
     "lint": "oxlint src",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "start": "turbo run start",
-    "dev": "turbo run dev",
+    "dev": "WORKTREE_NAME=$([ \"$(basename $PWD)\" = \"acme-monorepo\" ] || basename $PWD) turbo dev",
     "lint": "oxlint .",
     "format": "oxfmt",
     "format:check": "oxfmt --check",

--- a/turbo.json
+++ b/turbo.json
@@ -30,7 +30,8 @@
     "dev": {
       "dependsOn": ["^build"],
       "cache": false,
-      "persistent": true
+      "persistent": true,
+      "env": ["WORKTREE_NAME"]
     },
     "start": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

- Replace branch-based worktree detection in portless with explicit directory-based naming.
- Root `dev` script captures `WORKTREE_NAME=$(basename $PWD)`, special-cased to empty for the main checkout (`acme-monorepo`).
- Per-app `dev` invokes `portless run --name ${WORKTREE_NAME:+${WORKTREE_NAME}.}acme.<slug>` (web/api/landing).
- Main checkout → empty `WORKTREE_NAME` → name is `acme.web` (canonical).
- Conductor worktree `feat-foo` → `WORKTREE_NAME=feat-foo` → name is `feat-foo.acme.web`.

No `dev:portless` script existed in root or any app, so there was nothing to delete. `turbo.json` already only references `dev`.

## Before / after

**Root `package.json`:**
```diff
-"dev": "turbo run dev",
+"dev": "WORKTREE_NAME=$([ \"$(basename $PWD)\" = \"acme-monorepo\" ] || basename $PWD) turbo dev",
```

**`apps/web/package.json`:**
```diff
-"dev": "portless run --name acme.web next dev",
+"dev": "portless run --name ${WORKTREE_NAME:+${WORKTREE_NAME}.}acme.web next dev",
```

**`apps/api/package.json`:**
```diff
-"dev": "portless run --name acme.api tsdown --watch --on-success \"node dist/index.mjs\"",
+"dev": "portless run --name ${WORKTREE_NAME:+${WORKTREE_NAME}.}acme.api tsdown --watch --on-success \"node dist/index.mjs\"",
```

**`apps/landing/package.json`:**
```diff
-"dev": "portless run --name acme.landing next dev",
+"dev": "portless run --name ${WORKTREE_NAME:+${WORKTREE_NAME}.}acme.landing next dev",
```

## Conductor setup script template

For worktrees, the conductor setup script template becomes:

```bash
#!/usr/bin/env bash
set -e
WORKTREE_NAME=$([ "$(basename $PWD)" = "acme-monorepo" ] || basename $PWD)
url() { echo "https://${WORKTREE_NAME:+${WORKTREE_NAME}.}$1.localhost"; }

cat > apps/web/.env.local <<EOF2
BETTER_AUTH_URL=$(url acme.api)
NEXT_PUBLIC_API_URL=$(url acme.api)
EOF2

cat > apps/api/.env.local <<EOF2
BETTER_AUTH_URL=$(url acme.api)
CORS_ORIGINS=$(url acme.web),$(url acme.landing)
TRUSTED_ORIGINS=$(url acme.web),$(url acme.landing)
EOF2

cat > apps/landing/.env.local <<EOF2
NEXT_PUBLIC_WEB_URL=$(url acme.web)
EOF2
```

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] In main checkout (`acme-monorepo`), `pnpm dev` produces names like `acme.web`, `acme.api`, `acme.landing`
- [ ] In a conductor worktree (e.g. `feat-foo`), `pnpm dev` produces names like `feat-foo.acme.web`