### PR TITLE
chore: remove agent-ci references

### DIFF
--- a/.env.agent-ci.example
+++ b/.env.agent-ci.example
@@ -1,8 +1,0 @@
-# agent-ci secrets — copy to .env.agent-ci (gitignored) and override as needed.
-# Mirrors the env block in .github/workflows/e2e.yml.
-
-CI=true
-DATABASE_URL=postgresql://test:test@localhost:5432/test
-BETTER_AUTH_SECRET=test-secret-minimum-32-characters-long-for-e2e
-BETTER_AUTH_URL=http://127.0.0.1:3000
-NEXT_PUBLIC_API_URL=http://127.0.0.1:4000

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ yarn-error.log*
 # local env files
 .env*
 !.env.example
-!.env.agent-ci.example
 
 # IDE
 .idea

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,26 +120,6 @@ branch fix-styles:    https://fix-styles.acme.web.localhost
 - `fallow.yml` — `pnpm fallow:dead` (cross-file dead code, unused exports, circular deps)
 - All use `permissions: { contents: read }` and `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`
 
-## Local CI (agent-ci)
-
-Run the full CI pipeline locally with [agent-ci](https://agent-ci.dev) before pushing — same workflows, ~0 ms cache, pause-on-failure.
-
-```bash
-pnpm ci:local         # full mirror (test + lint + format + fallow + e2e)
-pnpm ci:local:fast    # fast 4 (skips e2e) — also runs on git push via .husky/pre-push
-pnpm ci:local:e2e     # e2e only
-```
-
-On failure the runner pauses with the container alive. Fix the file, then:
-
-```bash
-pnpm exec agent-ci retry --name <runner-name>
-```
-
-Secrets (`${{ secrets.FOO }}`) come from `.env.agent-ci` (gitignored). Copy `.env.agent-ci.example` and fill in real values. Requires Docker (OrbStack on macOS).
-
-Before reporting a task done, agents should run `pnpm ci:local` and confirm green.
-
 ## Prisma
 
 `prisma.config.ts` uses `process.env.DATABASE_URL ?? ""` (not `env("DATABASE_URL")`) so `prisma generate` works in CI without database credentials.


### PR DESCRIPTION
## Summary
- Drop the `## Local CI (agent-ci)` section from `AGENTS.md`
- Delete `.env.agent-ci.example` and its `.gitignore` exception
- Mirrors the orchestrator cleanup in c51e543 (chore: remove openlogs and agent-ci)

## Test plan
- [ ] CI passes (no `pnpm ci:local` script remains; nothing to break)
- [ ] `rg 'agent-ci|openlogs'` returns no tracked-file matches