### PR TITLE
fix(auth): gate useSecureCookies on WEB_APP_URL being HTTPS

### DIFF
--- a/packages/auth/src/server.test.ts
+++ b/packages/auth/src/server.test.ts
@@ -41,15 +41,25 @@ describe("Auth Server Configuration", () => {
     expect(auth.options.advanced?.cookiePrefix).toBe("acme");
   });
 
-  it("should not set useSecureCookies — protocol: auto in baseURL handles it", () => {
-    // useSecureCookies is intentionally absent: baseURL.protocol="auto"
-    // flips the `secure` cookie flag based on x-forwarded-proto / request
-    // URL, so a static gate would re-introduce the HTTPS-in-CI footgun.
-    // Cast via Record to read the field even though our typed surface drops it.
-    const advanced = auth.options.advanced as Record<string, unknown> | undefined;
-    expect(advanced?.useSecureCookies).toBeUndefined();
+  it("should gate useSecureCookies on WEB_APP_URL being HTTPS", () => {
+    // Without WEB_APP_URL the gate evaluates to false — CI runs on plain
+    // http://127.0.0.1, so cookies must not get the Secure flag (browsers
+    // drop Secure cookies on HTTP).
+    expect(auth.options.advanced?.useSecureCookies).toBe(false);
     expect(auth.options.advanced?.defaultCookieAttributes?.httpOnly).toBe(true);
     expect(auth.options.advanced?.defaultCookieAttributes?.sameSite).toBe("lax");
+  });
+
+  it("should set useSecureCookies when WEB_APP_URL is HTTPS", () => {
+    vi.stubEnv("WEB_APP_URL", "https://acme.web.localhost");
+    const httpsAuth = createAuth({ prisma, secret: "test-secret-minimum-32-characters-long" });
+    expect(httpsAuth.options.advanced?.useSecureCookies).toBe(true);
+  });
+
+  it("should NOT set useSecureCookies when WEB_APP_URL is HTTP", () => {
+    vi.stubEnv("WEB_APP_URL", "http://localhost:3000");
+    const httpAuth = createAuth({ prisma, secret: "test-secret-minimum-32-characters-long" });
+    expect(httpAuth.options.advanced?.useSecureCookies).toBe(false);
   });
 
   it("should configure dynamic baseURL with allowedHosts + protocol auto", () => {

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -56,10 +56,20 @@ export const createAuth = (config: AuthConfig) => {
         httpOnly: true,
         sameSite: "lax" as const,
       },
-      // `useSecureCookies` is omitted intentionally — `baseURL.protocol: "auto"`
-      // derives the scheme from `x-forwarded-proto` / request URL and flips
-      // the `secure` cookie flag automatically. Forcing it here would re-
-      // introduce the HTTPS-in-CI footgun.
+      // Force the `Secure` cookie flag when WEB_APP_URL is HTTPS. The
+      // dynamic-baseURL `protocol: "auto"` setting documents this as
+      // automatic, but in practice under Next.js + a reverse proxy
+      // (portless in dev, Vercel in prod), Better Auth doesn't reliably
+      // see the HTTPS scheme via `x-forwarded-proto` or `request.url`,
+      // so cookies end up without `Secure`.
+      //
+      // WEB_APP_URL is the explicit signal we already use everywhere:
+      // set to `https://acme.web.localhost` in dev (.env.example) and
+      // `https://app.acme.com` in prod; unset in CI (which runs on
+      // plain http://127.0.0.1) — so the gate naturally avoids the
+      // HTTPS-in-CI footgun that bare `true` or NODE_ENV gating would
+      // re-introduce.
+      useSecureCookies: process.env.WEB_APP_URL?.startsWith("https://") === true,
     },
 
     // Explicit to match the Next.js route handler mount at /api/auth/[...all].


### PR DESCRIPTION
## Summary

Propagates the same fix landed in easeia-monorepo #61: Better Auth's dynamic-baseURL `protocol: "auto"` is *documented* as flipping the `Secure` cookie flag based on the detected request scheme, but in practice under Next.js + reverse proxy (portless in dev, Vercel in prod), Better Auth doesn't reliably see HTTPS via `x-forwarded-proto` or `request.url` — cookies end up without `Secure`.

Bring back an explicit gate tied to **`WEB_APP_URL`**, the env var we already use for the canonical web origin:

| Environment | `WEB_APP_URL` | `useSecureCookies` |
|-------------|---------------|--------------------|
| Dev (portless) | `https://acme.web.localhost` (in `apps/web/.env.example`) | `true` ✓ |
| Prod | `https://app.acme.com` | `true` ✓ |
| CI | unset (workflow doesn't define it) | `false` ✓ |

Mirrors the original `BETTER_AUTH_URL?.startsWith("https://")` pattern that was removed during the dynamic-baseURL migration, without resurrecting that env var.

## Test plan

- [x] `pnpm test --filter=@repo/auth` passes (29 tests including 2 new branches of the gate)
- [ ] After merge: log in fresh, DevTools → Cookies → confirm `Secure ✓` on `acme.session_token`