### PR TITLE
chore: drop nodeLinker:hoisted

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 auto-install-peers=true
-node-linker=hoisted

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -28,7 +28,8 @@
     "@types/react": "^19.2.14",
     "react": "^19.2.6",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.5"
+    "vitest": "^4.1.5",
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "@tanstack/react-form": "^1.29.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.3(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   packages/config-typescript: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,8 +2,6 @@ packages:
   - apps/*
   - packages/*
 
-nodeLinker: hoisted
-
 allowBuilds:
   "@prisma/engines": true
   esbuild: true


### PR DESCRIPTION
## Summary

Removes `nodeLinker: hoisted` from `pnpm-workspace.yaml` and `node-linker=hoisted` from `.npmrc`, switching to pnpm's default isolated linker. Phantom dependencies that were only resolving via hoisting are now explicitly declared.

## Changes

| File | Change |
|------|--------|
| `pnpm-workspace.yaml` | Removed `nodeLinker: hoisted` |
| `.npmrc` | Removed `node-linker=hoisted` |
| `packages/auth/package.json` | Added `zod@^4.4.3` to `devDependencies` (phantom dep: `import type { z } from "zod"` in `auth-form.ts`) |

## Test plan

- [x] `rm -rf node_modules && pnpm install` completes cleanly
- [x] `pnpm typecheck` passes (8/8 tasks successful)
- [x] `pnpm build` passes (5/5 tasks successful)
- [ ] CI must be green