### PR TITLE
test(e2e): update POMs to locate Sonner toast for root errors

### DIFF
--- a/tests/e2e/pages/login.page.ts
+++ b/tests/e2e/pages/login.page.ts
@@ -11,8 +11,9 @@ export class LoginPage {
     this.emailInput = page.getByLabel(/email/i);
     this.passwordInput = page.getByLabel(/password/i);
     this.submitButton = page.getByRole("button", { name: /sign in|log in/i });
-    // Root errors render via a <p class="text-sm text-destructive"> sibling.
-    this.rootError = page.locator("p.text-destructive");
+    // Root errors render as a Sonner toast (`toast.error(message)` from @repo/ui/components/sonner).
+    // Sonner emits error toasts as <li data-sonner-toast data-type="error">.
+    this.rootError = page.locator('[data-sonner-toast][data-type="error"]');
   }
 
   goto = async () => {

--- a/tests/e2e/pages/register.page.ts
+++ b/tests/e2e/pages/register.page.ts
@@ -15,8 +15,9 @@ export class RegisterPage {
     this.passwordInput = page.getByLabel("Password", { exact: true });
     this.confirmPasswordInput = page.getByLabel(/confirm password/i);
     this.submitButton = page.getByRole("button", { name: /create account/i });
-    // Root errors render via a <p class="text-sm text-destructive"> sibling.
-    this.rootError = page.locator("p.text-destructive");
+    // Root errors render as a Sonner toast (`toast.error(message)` from @repo/ui/components/sonner).
+    // Sonner emits error toasts as <li data-sonner-toast data-type="error">.
+    this.rootError = page.locator('[data-sonner-toast][data-type="error"]');
   }
 
   goto = async () => {

--- a/tests/e2e/pages/reset-password.page.ts
+++ b/tests/e2e/pages/reset-password.page.ts
@@ -14,8 +14,9 @@ export class ResetPasswordPage {
     this.passwordInput = page.getByLabel("New password", { exact: true });
     this.confirmPasswordInput = page.getByLabel(/confirm password/i);
     this.submitButton = page.getByRole("button", { name: /reset password/i });
-    // Root errors render via a <p class="text-sm text-destructive"> sibling.
-    this.rootError = page.locator("p.text-destructive");
+    // Root errors render as a Sonner toast (`toast.error(message)` from @repo/ui/components/sonner).
+    // Sonner emits error toasts as <li data-sonner-toast data-type="error">.
+    this.rootError = page.locator('[data-sonner-toast][data-type="error"]');
   }
 
   goto = async (token?: string) => {


### PR DESCRIPTION
Follow-up to #89 — that PR removed the inline `<p class=text-destructive>` rootError block and moved root errors to Sonner toasts, but the 3 e2e POMs still located the old DOM element. Updates `login/register/reset-password.page.ts` to locate `[data-sonner-toast][data-type=error]` instead. Method signatures and field names unchanged. (acme has no GitHub Actions CI so this didn't surface as red — discovered via easeia where parallel CI flagged it.)