### PR TITLE
test(e2e): assert field errors for Zod validation; toast for server errors

### DIFF
--- a/tests/e2e/auth/login.spec.ts
+++ b/tests/e2e/auth/login.spec.ts
@@ -24,11 +24,11 @@ test.describe("Login", () => {
     expect(page.url()).toContain("/login");
   });
 
-  test("shows validation error for invalid email", async ({ loginPage }) => {
+  test("shows validation error for invalid email", async ({ loginPage, page }) => {
     await loginPage.goto();
     await loginPage.login("not-an-email", TEST_USER.password);
 
-    await loginPage.expectErrorVisible();
+    await expect(page.getByText(/invalid email/i)).toBeVisible();
   });
 });
 

--- a/tests/e2e/auth/register.spec.ts
+++ b/tests/e2e/auth/register.spec.ts
@@ -52,7 +52,7 @@ test.describe("Register", () => {
       "DifferentPassword!",
     );
 
-    await registerPage.expectErrorText("Passwords do not match");
+    await expect(page.getByText("Passwords do not match")).toBeVisible();
     expect(page.url()).toContain("/register");
   });
 

--- a/tests/e2e/auth/reset-password.spec.ts
+++ b/tests/e2e/auth/reset-password.spec.ts
@@ -25,7 +25,7 @@ test.describe("Reset Password", () => {
     await resetPasswordPage.goto("any-token-value");
     await resetPasswordPage.submit("NewPassword123!", "DifferentPassword1!");
 
-    await resetPasswordPage.expectErrorText(/passwords do not match/i);
+    await expect(page.getByText(/passwords do not match/i)).toBeVisible();
     expect(page.url()).toContain("/reset-password");
   });
 
@@ -46,8 +46,8 @@ test.describe("Reset Password", () => {
     await resetPasswordPage.submit("ValidPassword123!", "ValidPassword123!");
 
     // Better Auth rejects unknown tokens — the form surfaces the server message
-    // (varies by version, but always renders into the destructive root error).
-    await expect(page.locator("p.text-destructive")).toBeVisible();
+    // via a Sonner toast (toast.error from @repo/ui/components/sonner).
+    await expect(page.locator('[data-sonner-toast][data-type="error"]')).toBeVisible();
     expect(page.url()).toContain("/reset-password");
   });
 });


### PR DESCRIPTION
Follow-up to #91 — that PR updated all 3 POMs to locate `[data-sonner-toast][data-type=error]`, but didn't realize 3 tests were actually asserting **Zod client-side validation** (per-field `<FieldError>`, not a toast). Fixes them.

| Test | Surface | Fix |
|---|---|---|
| login "shows validation error for invalid email" | Zod onSubmit → `<FieldError>` | `page.getByText(/invalid email/i)` |
| register "shows error for mismatched passwords" | Zod refine → confirm field | `page.getByText("Passwords do not match")` |
| reset-password "shows error when passwords do not match" | Zod refine → confirm field | `page.getByText(/passwords do not match/i)` |
| reset-password "rejects an invalid token at the auth server" | server error → toast | `page.locator('[data-sonner-toast][data-type="error"]')` |

Discovered during easeia #73 CI re-run (same suite shape, same conflated assertions).

## Test plan
- [x] typecheck/lint green
- [ ] CI: acme has no GH Actions; local manual run pending