### PR TITLE
feat(api): @hono/structured-logger + dev pino-pretty transport

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.2",
+    "@hono/structured-logger": "^0.1.0",
     "@hono/zod-openapi": "^1.4.0",
     "@repo/auth": "workspace:*",
     "@repo/db": "workspace:*",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,11 +1,13 @@
 import "dotenv/config";
 
 import { serve } from "@hono/node-server";
+import { structuredLogger } from "@hono/structured-logger";
 import { createRoute, z } from "@hono/zod-openapi";
 import { prisma } from "@repo/db";
 import { createMarkdownFromOpenApi } from "@scalar/openapi-to-markdown";
 import { compress } from "hono/compress";
 import { cors } from "hono/cors";
+import { requestId } from "hono/request-id";
 
 import { env } from "./lib/env";
 import { logger } from "./lib/logger";
@@ -13,7 +15,6 @@ import { createOpenAPIApp } from "./lib/openapi";
 import { errorHandler, notFound } from "./middleware/error-handler";
 import {
   apiRateLimit,
-  requestId,
   requestSizeLimit,
   securityHeaders,
   standardRateLimit,
@@ -22,7 +23,13 @@ import { v1UserRoutes } from "./routes/v1/users";
 
 const app = createOpenAPIApp();
 
-app.use("*", requestId);
+app.use("*", requestId());
+app.use(
+  "*",
+  structuredLogger({
+    createLogger: (c) => logger.child({ requestId: c.var.requestId }),
+  }),
+);
 app.use("*", compress());
 app.use("*", requestSizeLimit());
 app.use("*", securityHeaders);
@@ -36,7 +43,7 @@ app.use(
   }),
 );
 
-// Skip logging for health checks
+// Skip logging for health checks; emit timing log for all other requests
 app.use("*", async (c, next) => {
   if (c.req.path === "/healthz") {
     return next();
@@ -46,7 +53,7 @@ app.use("*", async (c, next) => {
   await next();
   const ms = Date.now() - start;
 
-  logger.info({
+  c.var.logger.info({
     duration: ms,
     method: c.req.method,
     status: c.res.status,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -136,7 +136,7 @@ app.openapi(readyzRoute, async (c) => {
       200,
     );
   } catch (error) {
-    logger.error({ error }, "Readiness check failed");
+    c.var.logger.error({ error }, "Readiness check failed");
     return c.json(
       {
         checks: { database: "unhealthy" as const },

--- a/apps/api/src/lib/logger.ts
+++ b/apps/api/src/lib/logger.ts
@@ -4,7 +4,7 @@ import { env } from "./env";
 
 const logLevel = env.NODE_ENV === "production" ? "info" : "debug";
 
-export const logger = pino({
+const logger = pino({
   base: {
     env: env.NODE_ENV,
   },
@@ -13,4 +13,7 @@ export const logger = pino({
     paths: ["req.headers.authorization", "req.headers.cookie", "res.headers"],
     remove: true,
   },
+  transport: env.NODE_ENV === "production" ? undefined : { target: "pino-pretty" },
 });
+
+export { logger };

--- a/apps/api/src/lib/openapi.ts
+++ b/apps/api/src/lib/openapi.ts
@@ -1,5 +1,14 @@
+import type { BaseLogger } from "@hono/structured-logger";
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { Scalar } from "@scalar/hono-api-reference";
+
+declare module "hono" {
+  // oxlint-disable-next-line consistent-type-definitions -- declaration merging requires interface, not type
+  interface ContextVariableMap {
+    logger: BaseLogger;
+    requestId: string;
+  }
+}
 
 const createOpenAPIApp = <V extends Record<string, unknown> = Record<string, never>>() => {
   const app = new OpenAPIHono<{ Variables: V }>();

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -3,7 +3,6 @@ import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
 
 import { auth } from "../lib/auth";
-import { logger } from "../lib/logger";
 
 export type AuthVariables = {
   user: {
@@ -38,7 +37,7 @@ export const authMiddleware = createMiddleware<{ Variables: AuthVariables }>(
     try {
       session = await auth.api.getSession({ headers });
     } catch (error) {
-      logger.error(
+      c.var.logger.error(
         { error, method: c.req.method, url: c.req.url },
         "authMiddleware: getSession threw — auth service unavailable",
       );
@@ -82,7 +81,7 @@ export const optionalAuthMiddleware = createMiddleware<{
     // Unexpected failures (DB down, malformed token, rate limit exception) must
     // not be silently discarded — a missing user context is otherwise
     // indistinguishable from an infrastructure outage.
-    logger.error(
+    c.var.logger.error(
       { error, method: c.req.method, url: c.req.url },
       "optionalAuthMiddleware: getSession threw unexpectedly",
     );

--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -4,7 +4,6 @@ import { HTTPException } from "hono/http-exception";
 import { ZodError } from "zod";
 
 import { env } from "@/lib/env";
-import { logger } from "@/lib/logger";
 
 export const isPrismaKnownError = (
   err: unknown,
@@ -31,7 +30,7 @@ export class AppError extends Error {
 }
 
 export const errorHandler = (err: Error, c: Context) => {
-  logger.error({
+  c.var.logger.error({
     err,
     ip: c.req.header("x-forwarded-for") || c.req.header("x-real-ip"),
     method: c.req.method,

--- a/apps/api/src/middleware/security.test.ts
+++ b/apps/api/src/middleware/security.test.ts
@@ -1,7 +1,7 @@
 import type { Context } from "hono";
 import { describe, expect, it, vi } from "vitest";
 
-import { requestId, requestSizeLimit } from "./security";
+import { requestSizeLimit } from "./security";
 
 const createMockContext = (options: { headers?: Record<string, string> } = {}) => {
   const { headers = {} } = options;
@@ -76,42 +76,5 @@ describe("requestSizeLimit", () => {
       { error: { code: "PAYLOAD_TOO_LARGE", message: "Request entity too large" } },
       413,
     );
-  });
-});
-
-describe("requestId", () => {
-  const next = vi.fn();
-
-  it("should use existing x-request-id header", async () => {
-    const c = createMockContext({ headers: { "x-request-id": "existing-id" } });
-
-    await requestId(c, next);
-
-    expect(c.set).toHaveBeenCalledWith("requestId", "existing-id");
-    expect(c.header).toHaveBeenCalledWith("x-request-id", "existing-id");
-  });
-
-  it("should generate UUID when no x-request-id header", async () => {
-    const mockUuid = "generated-uuid-1234";
-    vi.spyOn(crypto, "randomUUID").mockReturnValue(
-      mockUuid as `${string}-${string}-${string}-${string}-${string}`,
-    );
-
-    const c = createMockContext();
-
-    await requestId(c, next);
-
-    expect(c.set).toHaveBeenCalledWith("requestId", mockUuid);
-    expect(c.header).toHaveBeenCalledWith("x-request-id", mockUuid);
-
-    vi.restoreAllMocks();
-  });
-
-  it("should call next", async () => {
-    const c = createMockContext({ headers: { "x-request-id": "test" } });
-
-    await requestId(c, next);
-
-    expect(next).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/middleware/security.ts
+++ b/apps/api/src/middleware/security.ts
@@ -89,10 +89,3 @@ export const requestSizeLimit = (maxSize: number = 10 * 1024 * 1024) => {
     await next();
   };
 };
-
-export const requestId = async (c: Context, next: Next) => {
-  const id = c.req.header("x-request-id") || crypto.randomUUID();
-  c.set("requestId", id);
-  c.header("x-request-id", id);
-  await next();
-};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@hono/node-server':
         specifier: ^2.0.2
         version: 2.0.2(hono@4.12.18)
+      '@hono/structured-logger':
+        specifier: ^0.1.0
+        version: 0.1.0(hono@4.12.18)
       '@hono/zod-openapi':
         specifier: ^1.4.0
         version: 1.4.0(hono@4.12.18)(zod@4.4.3)
@@ -1261,6 +1264,12 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
+
+  '@hono/structured-logger@0.1.0':
+    resolution: {integrity: sha512-06QUXbNnvb6lSJz/79WcC8yhGCbWT4EO2Zq3rodzQLwUT40OVXNerCKXUcwv4KgVZGKhVebzv1Vr84w/GKEl6Q==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      hono: '>=4.0.0'
 
   '@hono/zod-openapi@1.4.0':
     resolution: {integrity: sha512-AFchqR1N/NxfI4hUOSGI2/g8zLROxA1OE7Oh5JJFlTaGxhrdRyH+93gd0tIBpb0z8s9r8hUoNnaOBfHbdb4NMw==}
@@ -6754,6 +6763,10 @@ snapshots:
       hono: 4.12.18
 
   '@hono/node-server@2.0.2(hono@4.12.18)':
+    dependencies:
+      hono: 4.12.18
+
+  '@hono/structured-logger@0.1.0(hono@4.12.18)':
     dependencies:
       hono: 4.12.18
 


### PR DESCRIPTION
- Wires \`@hono/structured-logger\` to expose \`c.var.logger\` as a per-request child of the root pino logger, bound to \`requestId\`.
- Switches to Hono's built-in \`requestId()\` middleware (deletes the hand-rolled one in \`middleware/security.ts\`).
- Adds \`transport: { target: "pino-pretty" }\` in dev (NODE_ENV !== "production") to \`lib/logger.ts\` — prod stays raw JSON for log aggregators.
- Request-scoped log calls migrated to \`c.var.logger\`; non-request callers keep importing the root \`logger\` from \`./lib/logger\`.
- Augments Hono's \`ContextVariableMap\` in \`lib/openapi.ts\` for full TypeScript coverage of \`c.var.logger\` and \`c.var.requestId\`.
- Removes stale \`requestId\` unit tests (the built-in middleware is Hono's own concern to test).

## Test plan
- [x] \`pnpm build\` green
- [x] \`typecheck\` green (zero errors)
- [x] \`oxlint\` 0 warnings, 0 errors
- [x] \`format:check\` — only pre-existing e2e/auth-email drift, no new issues
- [ ] CI green
- [ ] Manual: \`NODE_ENV=development pnpm --filter api dev\` shows colored pino-pretty output