### PR TITLE
feat: modern-web-guidance fixes (a11y, autocomplete, color-scheme, semantics)

### DIFF
--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import "@/styles/globals.css";
 
 import { cn } from "@repo/ui/lib/utils";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 
 import { AnalyticsWrapper } from "@/components/analytics";
@@ -17,6 +17,17 @@ const LONG_DESCRIPTION = "Monorepo for base projects";
 const TWITTER_HANDLE = "acme";
 
 const SITE_URL = "https://www.acme-monorepo.com";
+
+export const viewport: Viewport = {
+  initialScale: 1,
+  maximumScale: 5,
+  themeColor: [
+    { color: "white", media: "(prefers-color-scheme: light)" },
+    { color: "black", media: "(prefers-color-scheme: dark)" },
+  ],
+  userScalable: true,
+  width: "device-width",
+};
 
 const metadata = {
   description: LONG_DESCRIPTION,
@@ -53,6 +64,7 @@ const metadata = {
 } satisfies Metadata;
 
 const inter = Inter({
+  display: "swap",
   subsets: ["latin"],
   variable: "--font-sans",
 });
@@ -66,8 +78,16 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
           inter.variable,
         )}
       >
+        <a
+          className="sr-only fixed top-2 left-2 z-50 rounded-md bg-background px-3 py-2 text-sm font-medium text-foreground ring-1 ring-ring focus:not-sr-only"
+          href="#main-content"
+        >
+          Skip to content
+        </a>
         <Header />
-        <main className="flex-1">{children}</main>
+        <main className="flex-1" id="main-content">
+          {children}
+        </main>
         <Footer />
 
         <AnalyticsWrapper />

--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -6,7 +6,7 @@ import { webAppUrl } from "@/lib/urls";
 
 export const metadata: Metadata = {
   description: "Welcome to Acme — the one template to rule them all.",
-  title: "Home",
+  title: { absolute: "Acme — The one template to rule them all" },
 };
 
 const Page = () => {

--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -2,9 +2,12 @@ import type { ReactNode } from "react";
 
 const Layout = ({ children }: { children: ReactNode }) => {
   return (
-    <div className="flex min-h-svh flex-col items-center justify-center bg-muted p-6 md:p-10">
+    <main
+      className="flex min-h-svh flex-col items-center justify-center bg-muted p-6 md:p-10"
+      id="main-content"
+    >
       <div className="flex w-full max-w-sm flex-col gap-6">{children}</div>
-    </div>
+    </main>
   );
 };
 

--- a/apps/web/src/app/(auth)/login/form.tsx
+++ b/apps/web/src/app/(auth)/login/form.tsx
@@ -7,10 +7,12 @@ import {
   FieldError,
   FieldGroup,
   FieldLabel,
+  useFieldContext,
 } from "@repo/ui/components/field";
 import { Input } from "@repo/ui/components/input";
 import { toast } from "@repo/ui/components/sonner";
 import { useForm } from "@tanstack/react-form";
+import { Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -22,14 +24,88 @@ type Props = {
   from: string;
 };
 
+type FieldInputProps = {
+  errors: Array<unknown>;
+  isInvalid: boolean;
+  isLoading: boolean;
+  name: string;
+  onBlur: () => void;
+  onChange: (v: string) => void;
+  value: string;
+};
+
+// These are proper React components so they can call useFieldContext inside <Field>.
+const EmailFieldInput = ({
+  errors,
+  isInvalid,
+  isLoading,
+  name,
+  onBlur,
+  onChange,
+  value,
+}: FieldInputProps) => {
+  const { id } = useFieldContext();
+  return (
+    <>
+      <Input
+        aria-describedby={isInvalid ? `${id}-error` : undefined}
+        aria-invalid={isInvalid}
+        autoComplete="email"
+        disabled={isLoading}
+        id="email"
+        name={name}
+        onBlur={onBlur}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="m@example.com"
+        required
+        type="email"
+        value={value}
+      />
+      {isInvalid && <FieldError errors={errors} />}
+    </>
+  );
+};
+
+const PasswordFieldInput = ({
+  errors,
+  isInvalid,
+  isLoading,
+  name,
+  onBlur,
+  onChange,
+  value,
+}: FieldInputProps) => {
+  const { id } = useFieldContext();
+  return (
+    <>
+      <Input
+        aria-describedby={isInvalid ? `${id}-error` : undefined}
+        aria-invalid={isInvalid}
+        autoComplete="current-password"
+        disabled={isLoading}
+        id="password"
+        name={name}
+        onBlur={onBlur}
+        onChange={(e) => onChange(e.target.value)}
+        required
+        type="password"
+        value={value}
+      />
+      {isInvalid && <FieldError errors={errors} />}
+    </>
+  );
+};
+
 const LoginForm = ({ from }: Props) => {
   const { push, refresh } = useRouter();
   const [isLoading, setIsLoading] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
 
   const form = useForm({
     defaultValues: { email: "", password: "" },
     onSubmit: async ({ value }) => {
       setIsLoading(true);
+      setFormError(null);
       try {
         const result = await authClient.signIn.email({
           email: value.email,
@@ -43,6 +119,7 @@ const LoginForm = ({ from }: Props) => {
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "An error occurred. Please try again.";
+        setFormError(message);
         toast.error(message);
       } finally {
         setIsLoading(false);
@@ -60,6 +137,9 @@ const LoginForm = ({ from }: Props) => {
         void form.handleSubmit();
       }}
     >
+      <div aria-atomic="true" aria-live="polite" className="sr-only">
+        {formError}
+      </div>
       <FieldGroup>
         <form.Field name="email">
           {(field) => {
@@ -67,18 +147,15 @@ const LoginForm = ({ from }: Props) => {
             return (
               <Field data-invalid={isInvalid || undefined}>
                 <FieldLabel htmlFor="email">Email</FieldLabel>
-                <Input
-                  aria-invalid={isInvalid}
-                  disabled={isLoading}
-                  id="email"
+                <EmailFieldInput
+                  errors={field.state.meta.errors}
+                  isInvalid={isInvalid}
+                  isLoading={isLoading}
                   name={field.name}
                   onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  placeholder="m@example.com"
-                  type="email"
+                  onChange={field.handleChange}
                   value={field.state.value}
                 />
-                {isInvalid && <FieldError errors={field.state.meta.errors} />}
               </Field>
             );
           }}
@@ -98,25 +175,29 @@ const LoginForm = ({ from }: Props) => {
                     Forgot your password?
                   </Link>
                 </div>
-                <Input
-                  aria-invalid={isInvalid}
-                  disabled={isLoading}
-                  id="password"
+                <PasswordFieldInput
+                  errors={field.state.meta.errors}
+                  isInvalid={isInvalid}
+                  isLoading={isLoading}
                   name={field.name}
                   onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  type="password"
+                  onChange={field.handleChange}
                   value={field.state.value}
                 />
-                {isInvalid && <FieldError errors={field.state.meta.errors} />}
               </Field>
             );
           }}
         </form.Field>
 
         <Field>
-          <Button disabled={isLoading} type="submit">
-            {isLoading ? "Signing in..." : "Sign in"}
+          <Button
+            aria-busy={isLoading}
+            aria-disabled={isLoading}
+            className="aria-busy:pointer-events-none aria-busy:opacity-50"
+            type="submit"
+          >
+            {isLoading && <Loader2 className="size-4 animate-spin" />}
+            {isLoading ? "Signing in…" : "Sign in"}
           </Button>
           <FieldDescription className="text-center">
             Don&apos;t have an account?{" "}

--- a/apps/web/src/app/(auth)/recover/form.tsx
+++ b/apps/web/src/app/(auth)/recover/form.tsx
@@ -7,24 +7,69 @@ import {
   FieldError,
   FieldGroup,
   FieldLabel,
+  useFieldContext,
 } from "@repo/ui/components/field";
 import { Input } from "@repo/ui/components/input";
 import { toast } from "@repo/ui/components/sonner";
 import { useForm } from "@tanstack/react-form";
+import { Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 
 import { authClient } from "@/lib/auth-client";
 import { recoverSchema } from "@/lib/form-schemas";
 
+type EmailFieldInputProps = {
+  errors: Array<unknown>;
+  isInvalid: boolean;
+  isLoading: boolean;
+  name: string;
+  onBlur: () => void;
+  onChange: (v: string) => void;
+  value: string;
+};
+
+const EmailFieldInput = ({
+  errors,
+  isInvalid,
+  isLoading,
+  name,
+  onBlur,
+  onChange,
+  value,
+}: EmailFieldInputProps) => {
+  const { id } = useFieldContext();
+  return (
+    <>
+      <Input
+        aria-describedby={isInvalid ? `${id}-error` : undefined}
+        aria-invalid={isInvalid}
+        autoComplete="email"
+        disabled={isLoading}
+        id="email"
+        name={name}
+        onBlur={onBlur}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="m@example.com"
+        required
+        type="email"
+        value={value}
+      />
+      {isInvalid && <FieldError errors={errors} />}
+    </>
+  );
+};
+
 const RecoverForm = () => {
   const [submittedEmail, setSubmittedEmail] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
 
   const form = useForm({
     defaultValues: { email: "" },
     onSubmit: async ({ value }) => {
       setIsLoading(true);
+      setFormError(null);
       try {
         const result = await authClient.requestPasswordReset({
           email: value.email,
@@ -37,6 +82,7 @@ const RecoverForm = () => {
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "An error occurred. Please try again.";
+        setFormError(message);
         toast.error(message);
       } finally {
         setIsLoading(false);
@@ -73,6 +119,9 @@ const RecoverForm = () => {
         void form.handleSubmit();
       }}
     >
+      <div aria-atomic="true" aria-live="polite" className="sr-only">
+        {formError}
+      </div>
       <FieldGroup>
         <form.Field name="email">
           {(field) => {
@@ -80,26 +129,29 @@ const RecoverForm = () => {
             return (
               <Field data-invalid={isInvalid || undefined}>
                 <FieldLabel htmlFor="email">Email</FieldLabel>
-                <Input
-                  aria-invalid={isInvalid}
-                  disabled={isLoading}
-                  id="email"
+                <EmailFieldInput
+                  errors={field.state.meta.errors}
+                  isInvalid={isInvalid}
+                  isLoading={isLoading}
                   name={field.name}
                   onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  placeholder="m@example.com"
-                  type="email"
+                  onChange={field.handleChange}
                   value={field.state.value}
                 />
-                {isInvalid && <FieldError errors={field.state.meta.errors} />}
               </Field>
             );
           }}
         </form.Field>
 
         <Field>
-          <Button disabled={isLoading} type="submit">
-            {isLoading ? "Sending..." : "Send reset link"}
+          <Button
+            aria-busy={isLoading}
+            aria-disabled={isLoading}
+            className="aria-busy:pointer-events-none aria-busy:opacity-50"
+            type="submit"
+          >
+            {isLoading && <Loader2 className="size-4 animate-spin" />}
+            {isLoading ? "Sending…" : "Send reset link"}
           </Button>
           <FieldDescription className="text-center">
             Remembered your password?{" "}

--- a/apps/web/src/app/(auth)/register/form.tsx
+++ b/apps/web/src/app/(auth)/register/form.tsx
@@ -7,10 +7,12 @@ import {
   FieldError,
   FieldGroup,
   FieldLabel,
+  useFieldContext,
 } from "@repo/ui/components/field";
 import { Input } from "@repo/ui/components/input";
 import { toast } from "@repo/ui/components/sonner";
 import { useForm } from "@tanstack/react-form";
+import { Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -18,15 +20,63 @@ import { useState } from "react";
 import { authClient } from "@/lib/auth-client";
 import { registerSchema } from "@/lib/form-schemas";
 
+type FieldInputProps = {
+  autoComplete: string;
+  errors: Array<unknown>;
+  id: string;
+  isInvalid: boolean;
+  isLoading: boolean;
+  name: string;
+  onBlur: () => void;
+  onChange: (v: string) => void;
+  type?: string;
+  value: string;
+};
+
+const RegisterFieldInput = ({
+  autoComplete,
+  errors,
+  id,
+  isInvalid,
+  isLoading,
+  name,
+  onBlur,
+  onChange,
+  type = "text",
+  value,
+}: FieldInputProps) => {
+  const { id: fieldId } = useFieldContext();
+  return (
+    <>
+      <Input
+        aria-describedby={isInvalid ? `${fieldId}-error` : undefined}
+        aria-invalid={isInvalid}
+        autoComplete={autoComplete}
+        disabled={isLoading}
+        id={id}
+        name={name}
+        onBlur={onBlur}
+        onChange={(e) => onChange(e.target.value)}
+        required
+        type={type}
+        value={value}
+      />
+      {isInvalid && <FieldError errors={errors} />}
+    </>
+  );
+};
+
 const RegisterForm = () => {
   const { push, refresh } = useRouter();
   const [pendingVerificationEmail, setPendingVerificationEmail] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
 
   const form = useForm({
     defaultValues: { confirmPassword: "", email: "", name: "", password: "" },
     onSubmit: async ({ value }) => {
       setIsLoading(true);
+      setFormError(null);
       try {
         if (value.password !== value.confirmPassword) {
           throw new Error("Passwords do not match");
@@ -55,6 +105,7 @@ const RegisterForm = () => {
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "An error occurred. Please try again.";
+        setFormError(message);
         toast.error(message);
       } finally {
         setIsLoading(false);
@@ -95,6 +146,9 @@ const RegisterForm = () => {
         void form.handleSubmit();
       }}
     >
+      <div aria-atomic="true" aria-live="polite" className="sr-only">
+        {formError}
+      </div>
       <FieldGroup>
         <form.Field name="name">
           {(field) => {
@@ -102,17 +156,17 @@ const RegisterForm = () => {
             return (
               <Field data-invalid={isInvalid || undefined}>
                 <FieldLabel htmlFor="name">Full Name</FieldLabel>
-                <Input
-                  aria-invalid={isInvalid}
-                  disabled={isLoading}
+                <RegisterFieldInput
+                  autoComplete="name"
+                  errors={field.state.meta.errors}
                   id="name"
+                  isInvalid={isInvalid}
+                  isLoading={isLoading}
                   name={field.name}
                   onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  placeholder="John Doe"
+                  onChange={field.handleChange}
                   value={field.state.value}
                 />
-                {isInvalid && <FieldError errors={field.state.meta.errors} />}
               </Field>
             );
           }}
@@ -124,18 +178,18 @@ const RegisterForm = () => {
             return (
               <Field data-invalid={isInvalid || undefined}>
                 <FieldLabel htmlFor="email">Email</FieldLabel>
-                <Input
-                  aria-invalid={isInvalid}
-                  disabled={isLoading}
+                <RegisterFieldInput
+                  autoComplete="email"
+                  errors={field.state.meta.errors}
                   id="email"
+                  isInvalid={isInvalid}
+                  isLoading={isLoading}
                   name={field.name}
                   onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  placeholder="m@example.com"
+                  onChange={field.handleChange}
                   type="email"
                   value={field.state.value}
                 />
-                {isInvalid && <FieldError errors={field.state.meta.errors} />}
               </Field>
             );
           }}
@@ -148,17 +202,18 @@ const RegisterForm = () => {
               return (
                 <Field data-invalid={isInvalid || undefined}>
                   <FieldLabel htmlFor="password">Password</FieldLabel>
-                  <Input
-                    aria-invalid={isInvalid}
-                    disabled={isLoading}
+                  <RegisterFieldInput
+                    autoComplete="new-password"
+                    errors={field.state.meta.errors}
                     id="password"
+                    isInvalid={isInvalid}
+                    isLoading={isLoading}
                     name={field.name}
                     onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
+                    onChange={field.handleChange}
                     type="password"
                     value={field.state.value}
                   />
-                  {isInvalid && <FieldError errors={field.state.meta.errors} />}
                 </Field>
               );
             }}
@@ -170,17 +225,18 @@ const RegisterForm = () => {
               return (
                 <Field data-invalid={isInvalid || undefined}>
                   <FieldLabel htmlFor="confirmPassword">Confirm Password</FieldLabel>
-                  <Input
-                    aria-invalid={isInvalid}
-                    disabled={isLoading}
+                  <RegisterFieldInput
+                    autoComplete="new-password"
+                    errors={field.state.meta.errors}
                     id="confirmPassword"
+                    isInvalid={isInvalid}
+                    isLoading={isLoading}
                     name={field.name}
                     onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
+                    onChange={field.handleChange}
                     type="password"
                     value={field.state.value}
                   />
-                  {isInvalid && <FieldError errors={field.state.meta.errors} />}
                 </Field>
               );
             }}
@@ -188,8 +244,14 @@ const RegisterForm = () => {
         </div>
 
         <Field>
-          <Button disabled={isLoading} type="submit">
-            {isLoading ? "Creating account..." : "Create account"}
+          <Button
+            aria-busy={isLoading}
+            aria-disabled={isLoading}
+            className="aria-busy:pointer-events-none aria-busy:opacity-50"
+            type="submit"
+          >
+            {isLoading && <Loader2 className="size-4 animate-spin" />}
+            {isLoading ? "Creating account…" : "Create account"}
           </Button>
           <FieldDescription className="text-center">
             Already have an account?{" "}

--- a/apps/web/src/app/(auth)/reset-password/form.tsx
+++ b/apps/web/src/app/(auth)/reset-password/form.tsx
@@ -7,10 +7,12 @@ import {
   FieldError,
   FieldGroup,
   FieldLabel,
+  useFieldContext,
 } from "@repo/ui/components/field";
 import { Input } from "@repo/ui/components/input";
 import { toast } from "@repo/ui/components/sonner";
 import { useForm } from "@tanstack/react-form";
+import { Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -22,14 +24,60 @@ type Props = {
   token: string | null;
 };
 
+type PasswordFieldInputProps = {
+  autoComplete: string;
+  errors: Array<unknown>;
+  id: string;
+  isInvalid: boolean;
+  isLoading: boolean;
+  name: string;
+  onBlur: () => void;
+  onChange: (v: string) => void;
+  value: string;
+};
+
+const PasswordFieldInput = ({
+  autoComplete,
+  errors,
+  id,
+  isInvalid,
+  isLoading,
+  name,
+  onBlur,
+  onChange,
+  value,
+}: PasswordFieldInputProps) => {
+  const { id: fieldId } = useFieldContext();
+  return (
+    <>
+      <Input
+        aria-describedby={isInvalid ? `${fieldId}-error` : undefined}
+        aria-invalid={isInvalid}
+        autoComplete={autoComplete}
+        disabled={isLoading}
+        id={id}
+        name={name}
+        onBlur={onBlur}
+        onChange={(e) => onChange(e.target.value)}
+        required
+        type="password"
+        value={value}
+      />
+      {isInvalid && <FieldError errors={errors} />}
+    </>
+  );
+};
+
 const ResetPasswordForm = ({ token }: Props) => {
   const { push } = useRouter();
   const [isLoading, setIsLoading] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
 
   const form = useForm({
     defaultValues: { confirmPassword: "", password: "" },
     onSubmit: async ({ value }) => {
       setIsLoading(true);
+      setFormError(null);
       try {
         if (!token) {
           throw new Error("Invalid reset token. Please request a new password reset.");
@@ -48,6 +96,7 @@ const ResetPasswordForm = ({ token }: Props) => {
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "An error occurred. Please try again.";
+        setFormError(message);
         toast.error(message);
       } finally {
         setIsLoading(false);
@@ -64,6 +113,9 @@ const ResetPasswordForm = ({ token }: Props) => {
         void form.handleSubmit();
       }}
     >
+      <div aria-atomic="true" aria-live="polite" className="sr-only">
+        {formError}
+      </div>
       <FieldGroup>
         <div className="grid grid-cols-2 gap-4">
           <form.Field name="password">
@@ -72,17 +124,17 @@ const ResetPasswordForm = ({ token }: Props) => {
               return (
                 <Field data-invalid={isInvalid || undefined}>
                   <FieldLabel htmlFor="password">New password</FieldLabel>
-                  <Input
-                    aria-invalid={isInvalid}
-                    disabled={isLoading}
+                  <PasswordFieldInput
+                    autoComplete="new-password"
+                    errors={field.state.meta.errors}
                     id="password"
+                    isInvalid={isInvalid}
+                    isLoading={isLoading}
                     name={field.name}
                     onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                    type="password"
+                    onChange={field.handleChange}
                     value={field.state.value}
                   />
-                  {isInvalid && <FieldError errors={field.state.meta.errors} />}
                 </Field>
               );
             }}
@@ -94,17 +146,17 @@ const ResetPasswordForm = ({ token }: Props) => {
               return (
                 <Field data-invalid={isInvalid || undefined}>
                   <FieldLabel htmlFor="confirmPassword">Confirm password</FieldLabel>
-                  <Input
-                    aria-invalid={isInvalid}
-                    disabled={isLoading}
+                  <PasswordFieldInput
+                    autoComplete="new-password"
+                    errors={field.state.meta.errors}
                     id="confirmPassword"
+                    isInvalid={isInvalid}
+                    isLoading={isLoading}
                     name={field.name}
                     onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                    type="password"
+                    onChange={field.handleChange}
                     value={field.state.value}
                   />
-                  {isInvalid && <FieldError errors={field.state.meta.errors} />}
                 </Field>
               );
             }}
@@ -112,8 +164,14 @@ const ResetPasswordForm = ({ token }: Props) => {
         </div>
 
         <Field>
-          <Button disabled={isLoading} type="submit">
-            {isLoading ? "Resetting..." : "Reset password"}
+          <Button
+            aria-busy={isLoading}
+            aria-disabled={isLoading}
+            className="aria-busy:pointer-events-none aria-busy:opacity-50"
+            type="submit"
+          >
+            {isLoading && <Loader2 className="size-4 animate-spin" />}
+            {isLoading ? "Resetting…" : "Reset password"}
           </Button>
           <FieldDescription className="text-center">
             Back to{" "}

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,7 +1,10 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
 import { SignOutButton } from "@/components/sign-out-button";
 import { getSession } from "@/lib/auth-helpers";
+
+export const metadata: Metadata = { title: "Dashboard" };
 
 const Dashboard = async () => {
   const session = await getSession();

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -104,6 +104,12 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
         <meta content="1; mode=block" httpEquiv="X-XSS-Protection" />
       </head>
       <body className={inter.className} suppressHydrationWarning>
+        <a
+          className="sr-only fixed top-2 left-2 z-50 rounded-md bg-background px-3 py-2 text-sm font-medium text-foreground ring-1 ring-ring focus:not-sr-only"
+          href="#main-content"
+        >
+          Skip to content
+        </a>
         {children}
         <Toaster />
       </body>

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../lib/utils";
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=size-])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-[color,opacity,box-shadow,transform] outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=size-])]:size-4",
   {
     defaultVariants: {
       size: "default",

--- a/packages/ui/src/components/card.tsx
+++ b/packages/ui/src/components/card.tsx
@@ -28,19 +28,17 @@ const CardHeader = ({ className, ...props }: ComponentProps<"div">) => {
   );
 };
 
-const CardTitle = ({ className, ...props }: ComponentProps<"div">) => {
+const CardTitle = ({ children, className, ...props }: ComponentProps<"h2">) => {
   return (
-    <div
-      className={cn("leading-none font-semibold", className)}
-      data-slot="card-title"
-      {...props}
-    />
+    <h2 className={cn("leading-none font-semibold", className)} data-slot="card-title" {...props}>
+      {children}
+    </h2>
   );
 };
 
-const CardDescription = ({ className, ...props }: ComponentProps<"div">) => {
+const CardDescription = ({ className, ...props }: ComponentProps<"p">) => {
   return (
-    <div
+    <p
       className={cn("text-sm text-muted-foreground", className)}
       data-slot="card-description"
       {...props}

--- a/packages/ui/src/components/field.tsx
+++ b/packages/ui/src/components/field.tsx
@@ -48,6 +48,7 @@ const FieldError = ({
   errors,
   ...props
 }: ComponentProps<"p"> & { errors?: Array<unknown> }) => {
+  const { id } = useFieldContext();
   if (!errors || errors.length === 0) {
     return null;
   }
@@ -70,7 +71,12 @@ const FieldError = ({
     return null;
   }
   return (
-    <p className={cn("text-sm font-medium text-destructive", className)} {...props}>
+    <p
+      className={cn("text-sm font-medium text-destructive", className)}
+      id={`${id}-error`}
+      role="alert"
+      {...props}
+    >
       {messages.join(", ")}
     </p>
   );

--- a/packages/ui/src/components/skeleton.tsx
+++ b/packages/ui/src/components/skeleton.tsx
@@ -3,7 +3,7 @@ import type { HTMLAttributes } from "react";
 import { cn } from "../lib/utils";
 
 type SkeletonProps = HTMLAttributes<HTMLDivElement> & {
-  animation?: "pulse" | "wave" | "none";
+  animation?: "pulse" | "none";
   height?: string | number;
   variant?: "text" | "circular" | "rectangular" | "rounded";
   width?: string | number;
@@ -32,7 +32,6 @@ const Skeleton = ({
   const animationClasses = {
     none: "",
     pulse: "animate-pulse",
-    wave: "animate-shimmer",
   };
 
   return (

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -30,6 +30,7 @@
 }
 
 :root {
+  color-scheme: light;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -70,6 +71,7 @@
 }
 
 .dark {
+  color-scheme: dark;
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.145 0 0);


### PR DESCRIPTION
## Summary

Implements all 16 applicable findings from the modern-web-guidance recon (3 findings were out of scope per the spec).

## Forms (auth a11y)

- **autocomplete** on all four auth forms: `email`, `current-password` (login), `name`, `email`, `new-password` (register), `email` (recover), `new-password` (reset-password)
- **`required`** attribute added to every mandatory `<Input>` across all four auth forms
- **`aria-describedby`** wired to error elements: `FieldError` now renders with `id="{fieldId}-error"` (derived from existing `useId()` context in `Field`); input sub-components call `useFieldContext()` to read the same id and set `aria-describedby` when invalid. Each field section was extracted into a proper React component so hooks can be called inside the `<Field>` boundary.
- **`aria-busy` / `aria-disabled`** replace `disabled` on all four submit buttons; spinner (`<Loader2 className="size-4 animate-spin" />`) added before label text during loading state; `aria-live="polite"` region added near each form for error announcements
- **`autoFocus`** (finding #13): skipped — `jsx-a11y/no-autofocus` in `oxlint-config-awesomeness` bans the attribute; the lint rule takes precedence over the low-impact finding

## A11y / layout

- **Skip-to-content** link added as first child of `<body>` in both `apps/web/src/app/layout.tsx` and `apps/landing/src/app/layout.tsx`
- **Auth layout `<div>` → `<main id="main-content">`** in `apps/web/src/app/(auth)/layout.tsx`
- **Landing `<main id="main-content">`** wired in landing layout

## CSS

- **`color-scheme: light`** on `:root`, **`color-scheme: dark`** on `.dark` in `packages/ui/src/styles/globals.css`
- **`transition-all` → `transition-[color,opacity,box-shadow,transform]`** in `packages/ui/src/components/button.tsx`

## Semantics

- **`CardTitle` → `<h2>`** with explicit `{children}` to satisfy `jsx-a11y/heading-has-content` linter (judgement call: `role="heading"` triggered `prefer-tag-over-role`; explicit children spread resolves both)
- **`CardDescription` → `<p>`** in `packages/ui/src/components/card.tsx`
- **Skeleton `wave` variant removed** (zero callsites confirmed via grep; `animate-shimmer` keyframe was never defined)

## Perf / meta

- **`font-display: swap`** added to Inter in `apps/landing/src/app/layout.tsx`
- **`viewport` export** with `themeColor` added to landing layout (mirrors web app)
- **Landing root page title** changed to `{ absolute: "Acme — The one template to rule them all" }`
- **Dashboard `metadata`** added: `{ title: "Dashboard" }`

## Findings not implemented

- **Sonner `aria-live` (#11)**: no code change needed — Sonner has built-in `aria-live` and the `<Toaster>` in both layouts does not disable it
- **View Transitions / Container queries / Popover API / Image optimization**: out of scope per spec