### PR TITLE
chore(tests): apply oxfmt to e2e auth-email specs + verification fixture

### DIFF
--- a/tests/e2e/auth-email/change-email.spec.ts
+++ b/tests/e2e/auth-email/change-email.spec.ts
@@ -1,5 +1,5 @@
-import { prisma } from "@repo/db";
 import { expect, test } from "@playwright/test";
+import { prisma } from "@repo/db";
 
 import { webUrl } from "../../../playwright.config";
 import { verification } from "../fixtures/verification.fixture";
@@ -15,9 +15,7 @@ test.describe("Change email (two-stage confirmation + verification)", () => {
     await page.context().clearCookies();
 
     const currentEmail = makeTestEmail(testInfo).toLowerCase();
-    const newEmail = makeTestEmail(testInfo)
-      .toLowerCase()
-      .replace("delivered+", "delivered+new-");
+    const newEmail = makeTestEmail(testInfo).toLowerCase().replace("delivered+", "delivered+new-");
     const username = makeTestUsername(currentEmail);
     const password = "ChangeEmailPwd1!";
 

--- a/tests/e2e/auth-email/existing-user-signup.spec.ts
+++ b/tests/e2e/auth-email/existing-user-signup.spec.ts
@@ -1,5 +1,5 @@
-import { prisma } from "@repo/db";
 import { expect, test } from "@playwright/test";
+import { prisma } from "@repo/db";
 
 import { webUrl } from "../../../playwright.config";
 import { makeTestEmail, makeTestUsername } from "../helpers/test-email";
@@ -26,7 +26,12 @@ test.describe("Sign-up for an existing email (enumeration prevention)", () => {
     // server-side. The test verifies the *contract* (no error, same status
     // class) and the *side-effect ceiling* (no duplicate row).
     const second = await request.post(`${webUrl}/api/auth/sign-up/email`, {
-      data: { email, name: "Different Name", password: "SecondPassword2!", username: `${username}_2` },
+      data: {
+        email,
+        name: "Different Name",
+        password: "SecondPassword2!",
+        username: `${username}_2`,
+      },
     });
     expect([200, 201]).toContain(second.status());
 

--- a/tests/e2e/fixtures/verification.fixture.ts
+++ b/tests/e2e/fixtures/verification.fixture.ts
@@ -23,9 +23,7 @@ const requireSecret = (): string => {
 // `{email}` keyed with the auth secret. Reconstructing it lets tests skip
 // inbox polling entirely. See node_modules/better-auth/dist/api/routes/
 // email-verification.mjs:createEmailVerificationToken.
-const forVerifyEmail = async (
-  email: string,
-): Promise<{ token: string; url: string }> => {
+const forVerifyEmail = async (email: string): Promise<{ token: string; url: string }> => {
   const token = await signJWT({ email: email.toLowerCase() }, requireSecret(), 3600);
   const callbackURL = encodeURIComponent("/dashboard");
   const url = `${webUrl}/api/auth/verify-email?token=${token}&callbackURL=${callbackURL}`;
@@ -46,10 +44,7 @@ type ChangeEmailUrls = {
   verificationUrl: string;
 };
 
-const forChangeEmail = async (
-  currentEmail: string,
-  newEmail: string,
-): Promise<ChangeEmailUrls> => {
+const forChangeEmail = async (currentEmail: string, newEmail: string): Promise<ChangeEmailUrls> => {
   const secret = requireSecret();
   const callbackURL = encodeURIComponent("/dashboard");
   const basePayload = {


### PR DESCRIPTION
Pure formatting changes only. `pnpm oxfmt` against `tests/e2e/auth-email/` and `tests/e2e/fixtures/` produces this exact diff (verified — same 6/11/9 line signature).

## Changes
- `tests/e2e/auth-email/change-email.spec.ts` — import order alphabetized; long method chain collapsed onto one line
- `tests/e2e/auth-email/existing-user-signup.spec.ts` — formatting normalized
- `tests/e2e/fixtures/verification.fixture.ts` — formatting normalized

## Why now
These changes have been sitting in the local working tree across multiple sessions. Clearing the drift so future work isn't confused by always-dirty test files.

## Test plan
- [x] `pnpm typecheck` exit 0
- [x] `pnpm oxlint` exit 0
- [x] `pnpm run format:check` exit 0
- No behavior changes — pure formatting