### PR TITLE
fix(api): expose c.var.logger in middleware test mocks

### DIFF
--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -14,10 +14,6 @@ vi.mock("@/lib/env", () => ({
   env: { NODE_ENV: "test" },
 }));
 
-vi.mock("@/lib/logger", () => ({
-  logger: { error: vi.fn(), info: vi.fn() },
-}));
-
 import { auth } from "@/lib/auth";
 
 import { authMiddleware, optionalAuthMiddleware } from "./auth";
@@ -36,6 +32,7 @@ const createMockContext = (headers: Record<string, string> = {}) => {
     set: vi.fn((key: string, value: unknown) => {
       variables.set(key, value);
     }),
+    var: { logger: { error: vi.fn(), info: vi.fn() } },
   } as unknown as Context;
 };
 

--- a/apps/api/src/middleware/error-handler.test.ts
+++ b/apps/api/src/middleware/error-handler.test.ts
@@ -7,10 +7,6 @@ vi.mock("@/lib/env", () => ({
   env: { NODE_ENV: "development" },
 }));
 
-vi.mock("@/lib/logger", () => ({
-  logger: { error: vi.fn(), info: vi.fn() },
-}));
-
 import { env } from "@/lib/env";
 
 import { AppError, errorHandler, notFound } from "./error-handler";
@@ -23,6 +19,7 @@ const createMockContext = (headers: Record<string, string> = {}) => {
       method: "GET",
       url: "http://localhost/test",
     },
+    var: { logger: { error: vi.fn(), info: vi.fn() } },
   } as unknown as Context & { json: ReturnType<typeof vi.fn> };
 };
 


### PR DESCRIPTION
## Summary
- Unbreaks the 10 api middleware tests that started failing after the structured-logger migration (commit dbb2511).
- Adds `var: { logger }` to the test mock contexts and removes the now-dead `vi.mock("@/lib/logger")` calls (neither file imports the module anymore).

## Test plan
- [x] `pnpm --filter api test` → 56/56 passing
- [ ] CI green on merge

Preflight for the deslop & standardization series.