### PR TITLE
refactor: shared Context test helper + comment hygiene pass

### DIFF
--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -16,8 +16,6 @@ export const envSchema = z.object({
 const parsedEnv = envSchema.safeParse(process.env);
 
 if (!parsedEnv.success) {
-  // Throwing at module load aborts the process with a stack trace; preferable to
-  // process.exit which loses context and conflicts with unicorn/no-process-exit.
   throw new Error(
     `Invalid environment variables:\n${JSON.stringify(z.treeifyError(parsedEnv.error), null, 2)}`,
   );

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -1,4 +1,4 @@
-import type { Context, Next } from "hono";
+import type { Next } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -17,24 +17,7 @@ vi.mock("@/lib/env", () => ({
 import { auth } from "@/lib/auth";
 
 import { authMiddleware, optionalAuthMiddleware } from "./auth";
-
-const createMockContext = (headers: Record<string, string> = {}) => {
-  const variables = new Map<string, unknown>();
-
-  return {
-    get: vi.fn((key: string) => variables.get(key)),
-    req: {
-      header: vi.fn((name: string) => headers[name]),
-      method: "GET",
-      path: "/test",
-      url: "http://localhost/test",
-    },
-    set: vi.fn((key: string, value: unknown) => {
-      variables.set(key, value);
-    }),
-    var: { logger: { error: vi.fn(), info: vi.fn() } },
-  } as unknown as Context;
-};
+import { createMockContext } from "./test-helpers";
 
 const mockSession = {
   session: { id: "session-1" },
@@ -53,13 +36,13 @@ describe("authMiddleware", () => {
     vi.clearAllMocks();
   });
 
-  it("should set user on context when session is valid", async () => {
+  it("sets user on context when session is valid", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as never);
-    const c = createMockContext({ Authorization: "Bearer token123" });
+    const { ctx, mocks } = createMockContext({ headers: { Authorization: "Bearer token123" } });
 
-    await authMiddleware(c, next);
+    await authMiddleware(ctx, next);
 
-    expect(c.set).toHaveBeenCalledWith("user", {
+    expect(mocks.set).toHaveBeenCalledWith("user", {
       displayName: "Test User",
       email: "test@example.com",
       id: "user-1",
@@ -68,49 +51,49 @@ describe("authMiddleware", () => {
     expect(next).toHaveBeenCalled();
   });
 
-  it("should forward Authorization header to getSession", async () => {
+  it("forwards Authorization header to getSession", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as never);
-    const c = createMockContext({ Authorization: "Bearer abc" });
+    const { ctx } = createMockContext({ headers: { Authorization: "Bearer abc" } });
 
-    await authMiddleware(c, next);
+    await authMiddleware(ctx, next);
 
     const calledHeaders = vi.mocked(auth.api.getSession).mock.calls[0]?.[0]?.headers;
     expect(calledHeaders?.get("Authorization")).toBe("Bearer abc");
   });
 
-  it("should forward Cookie header to getSession", async () => {
+  it("forwards Cookie header to getSession", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as never);
-    const c = createMockContext({ Cookie: "session=abc123" });
+    const { ctx } = createMockContext({ headers: { Cookie: "session=abc123" } });
 
-    await authMiddleware(c, next);
+    await authMiddleware(ctx, next);
 
     const calledHeaders = vi.mocked(auth.api.getSession).mock.calls[0]?.[0]?.headers;
     expect(calledHeaders?.get("Cookie")).toBe("session=abc123");
   });
 
-  it("should throw 401 when session is null", async () => {
+  it("throws 401 when session is null", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValue(null as never);
-    const c = createMockContext();
+    const { ctx } = createMockContext();
 
-    await expect(authMiddleware(c, next)).rejects.toThrow(HTTPException);
-    await expect(authMiddleware(c, next)).rejects.toMatchObject({
+    await expect(authMiddleware(ctx, next)).rejects.toThrow(HTTPException);
+    await expect(authMiddleware(ctx, next)).rejects.toMatchObject({
       status: 401,
     });
   });
 
-  it("should throw 401 when session has no user", async () => {
+  it("throws 401 when session has no user", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValue({ session: {}, user: null } as never);
-    const c = createMockContext();
+    const { ctx } = createMockContext();
 
-    await expect(authMiddleware(c, next)).rejects.toThrow(HTTPException);
+    await expect(authMiddleware(ctx, next)).rejects.toThrow(HTTPException);
   });
 
-  it("should throw 503 when getSession throws", async () => {
+  it("throws 503 when getSession throws", async () => {
     vi.mocked(auth.api.getSession).mockRejectedValue(new Error("DB down"));
-    const c = createMockContext();
+    const { ctx } = createMockContext();
 
-    await expect(authMiddleware(c, next)).rejects.toThrow(HTTPException);
-    await expect(authMiddleware(c, next)).rejects.toMatchObject({
+    await expect(authMiddleware(ctx, next)).rejects.toThrow(HTTPException);
+    await expect(authMiddleware(ctx, next)).rejects.toMatchObject({
       status: 503,
     });
   });
@@ -123,13 +106,13 @@ describe("optionalAuthMiddleware", () => {
     vi.clearAllMocks();
   });
 
-  it("should set user when session is valid", async () => {
+  it("sets user when session is valid", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as never);
-    const c = createMockContext({ Authorization: "Bearer token" });
+    const { ctx, mocks } = createMockContext({ headers: { Authorization: "Bearer token" } });
 
-    await optionalAuthMiddleware(c, next);
+    await optionalAuthMiddleware(ctx, next);
 
-    expect(c.set).toHaveBeenCalledWith("user", {
+    expect(mocks.set).toHaveBeenCalledWith("user", {
       displayName: "Test User",
       email: "test@example.com",
       id: "user-1",
@@ -138,33 +121,33 @@ describe("optionalAuthMiddleware", () => {
     expect(next).toHaveBeenCalled();
   });
 
-  it("should call next without setting user when session is null", async () => {
+  it("calls next without setting user when session is null", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValue(null as never);
-    const c = createMockContext();
+    const { ctx, mocks } = createMockContext();
 
-    await optionalAuthMiddleware(c, next);
+    await optionalAuthMiddleware(ctx, next);
 
-    expect(c.set).not.toHaveBeenCalled();
+    expect(mocks.set).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalled();
   });
 
-  it("should call next without setting user when getSession throws", async () => {
+  it("calls next without setting user when getSession throws", async () => {
     vi.mocked(auth.api.getSession).mockRejectedValue(new Error("DB down"));
-    const c = createMockContext();
+    const { ctx, mocks } = createMockContext();
 
-    await optionalAuthMiddleware(c, next);
+    await optionalAuthMiddleware(ctx, next);
 
-    expect(c.set).not.toHaveBeenCalled();
+    expect(mocks.set).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalled();
   });
 
-  it("should not set user when session exists but user is null", async () => {
+  it("does not set user when session exists but user is null", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValue({ session: {}, user: null } as never);
-    const c = createMockContext();
+    const { ctx, mocks } = createMockContext();
 
-    await optionalAuthMiddleware(c, next);
+    await optionalAuthMiddleware(ctx, next);
 
-    expect(c.set).not.toHaveBeenCalled();
+    expect(mocks.set).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -78,9 +78,7 @@ export const optionalAuthMiddleware = createMiddleware<{
       });
     }
   } catch (error) {
-    // Unexpected failures (DB down, malformed token, rate limit exception) must
-    // not be silently discarded — a missing user context is otherwise
-    // indistinguishable from an infrastructure outage.
+    // Log unexpected failures; a missing user context is otherwise indistinguishable from an outage.
     c.var.logger.error(
       { error, method: c.req.method, url: c.req.url },
       "optionalAuthMiddleware: getSession threw unexpectedly",

--- a/apps/api/src/middleware/error-handler.test.ts
+++ b/apps/api/src/middleware/error-handler.test.ts
@@ -1,4 +1,3 @@
-import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { describe, expect, it, vi } from "vitest";
 import { ZodError } from "zod";
@@ -10,21 +9,10 @@ vi.mock("@/lib/env", () => ({
 import { env } from "@/lib/env";
 
 import { AppError, errorHandler, notFound } from "./error-handler";
-
-const createMockContext = (headers: Record<string, string> = {}) => {
-  return {
-    json: vi.fn((body: unknown, status?: number) => ({ body, status })),
-    req: {
-      header: vi.fn((name: string) => headers[name]),
-      method: "GET",
-      url: "http://localhost/test",
-    },
-    var: { logger: { error: vi.fn(), info: vi.fn() } },
-  } as unknown as Context & { json: ReturnType<typeof vi.fn> };
-};
+import { createMockContext } from "./test-helpers";
 
 describe("AppError", () => {
-  it("should use default statusCode 500 and isOperational true", () => {
+  it("uses default statusCode 500 and isOperational true", () => {
     const error = new AppError("Something broke");
     expect(error.message).toBe("Something broke");
     expect(error.statusCode).toBe(500);
@@ -32,38 +20,38 @@ describe("AppError", () => {
     expect(error.code).toBeUndefined();
   });
 
-  it("should accept custom statusCode and isOperational", () => {
+  it("accepts custom statusCode and isOperational", () => {
     const error = new AppError("Not found", 404, false);
     expect(error.statusCode).toBe(404);
     expect(error.isOperational).toBe(false);
   });
 
-  it("should accept optional error code", () => {
+  it("accepts optional error code", () => {
     const error = new AppError("Bad", 400, true, "VALIDATION_FAILED");
     expect(error.code).toBe("VALIDATION_FAILED");
   });
 
-  it("should have a stack trace", () => {
+  it("has a stack trace", () => {
     const error = new AppError("Test");
     expect(error.stack).toBeDefined();
   });
 });
 
 describe("errorHandler", () => {
-  it("should handle HTTPException", async () => {
-    const c = createMockContext();
+  it("handles HTTPException", async () => {
+    const { ctx, mocks } = createMockContext();
     const err = new HTTPException(403, { message: "Forbidden" });
 
-    await errorHandler(err, c);
+    await errorHandler(err, ctx);
 
-    expect(c.json).toHaveBeenCalledWith(
+    expect(mocks.json).toHaveBeenCalledWith(
       { error: { code: "HTTP_EXCEPTION", message: "Forbidden" } },
       403,
     );
   });
 
-  it("should handle ZodError with field details", async () => {
-    const c = createMockContext();
+  it("handles ZodError with field details", async () => {
+    const { ctx, mocks } = createMockContext();
     const err = new ZodError([
       {
         code: "too_small",
@@ -75,9 +63,9 @@ describe("errorHandler", () => {
       },
     ]);
 
-    await errorHandler(err, c);
+    await errorHandler(err, ctx);
 
-    expect(c.json).toHaveBeenCalledWith(
+    expect(mocks.json).toHaveBeenCalledWith(
       {
         error: {
           code: "VALIDATION_ERROR",
@@ -89,82 +77,82 @@ describe("errorHandler", () => {
     );
   });
 
-  it("should handle AppError with custom code", async () => {
-    const c = createMockContext();
+  it("handles AppError with custom code", async () => {
+    const { ctx, mocks } = createMockContext();
     const err = new AppError("User not found", 404, true, "USER_NOT_FOUND");
 
-    await errorHandler(err, c);
+    await errorHandler(err, ctx);
 
-    expect(c.json).toHaveBeenCalledWith(
+    expect(mocks.json).toHaveBeenCalledWith(
       { error: { code: "USER_NOT_FOUND", message: "User not found" } },
       404,
     );
   });
 
-  it("should handle AppError without code defaulting to APP_ERROR", async () => {
-    const c = createMockContext();
+  it("handles AppError without code defaulting to APP_ERROR", async () => {
+    const { ctx, mocks } = createMockContext();
     const err = new AppError("Something wrong", 422);
 
-    await errorHandler(err, c);
+    await errorHandler(err, ctx);
 
-    expect(c.json).toHaveBeenCalledWith(
+    expect(mocks.json).toHaveBeenCalledWith(
       { error: { code: "APP_ERROR", message: "Something wrong" } },
       422,
     );
   });
 
-  it("should handle P2002 as 409 DUPLICATE_ENTRY", async () => {
-    const c = createMockContext();
+  it("handles P2002 as 409 DUPLICATE_ENTRY", async () => {
+    const { ctx, mocks } = createMockContext();
     const err = Object.assign(new Error("Unique constraint failed"), {
       clientVersion: "7.0.0",
       code: "P2002",
     });
 
-    await errorHandler(err, c);
+    await errorHandler(err, ctx);
 
-    expect(c.json).toHaveBeenCalledWith(
+    expect(mocks.json).toHaveBeenCalledWith(
       { error: { code: "DUPLICATE_ENTRY", message: "A record with this value already exists" } },
       409,
     );
   });
 
-  it("should handle P2025 as 404 NOT_FOUND", async () => {
-    const c = createMockContext();
+  it("handles P2025 as 404 NOT_FOUND", async () => {
+    const { ctx, mocks } = createMockContext();
     const err = Object.assign(new Error("Record not found"), {
       clientVersion: "7.0.0",
       code: "P2025",
     });
 
-    await errorHandler(err, c);
+    await errorHandler(err, ctx);
 
-    expect(c.json).toHaveBeenCalledWith(
+    expect(mocks.json).toHaveBeenCalledWith(
       { error: { code: "NOT_FOUND", message: "Record not found" } },
       404,
     );
   });
 
-  it("should include error message and stack in development", async () => {
-    const c = createMockContext();
+  it("includes error message and stack in development", async () => {
+    const { ctx, mocks } = createMockContext();
     const err = new Error("dev error");
 
-    await errorHandler(err, c);
+    await errorHandler(err, ctx);
 
-    const call = c.json.mock.calls[0];
+    const call = mocks.json.mock.calls[0];
     expect(call?.[0]?.error?.message).toBe("dev error");
     expect(call?.[0]?.error?.stack).toBeDefined();
     expect(call?.[1]).toBe(500);
   });
 
-  it("should hide error message in production", async () => {
+  it("hides error message in production", async () => {
     const mutableEnv = env as { NODE_ENV: string };
     mutableEnv.NODE_ENV = "production";
 
-    const c = createMockContext();
+    const { ctx, mocks } = createMockContext();
     const err = new Error("secret detail");
 
-    await errorHandler(err, c);
+    await errorHandler(err, ctx);
 
-    const call = c.json.mock.calls[0];
+    const call = mocks.json.mock.calls[0];
     expect(call?.[0]?.error?.message).toBe("An unexpected error occurred");
     expect(call?.[0]?.error?.stack).toBeUndefined();
 
@@ -173,12 +161,12 @@ describe("errorHandler", () => {
 });
 
 describe("notFound", () => {
-  it("should return 404 with NOT_FOUND code", () => {
-    const c = createMockContext();
+  it("returns 404 with NOT_FOUND code", () => {
+    const { ctx, mocks } = createMockContext();
 
-    notFound(c);
+    notFound(ctx);
 
-    expect(c.json).toHaveBeenCalledWith(
+    expect(mocks.json).toHaveBeenCalledWith(
       { error: { code: "NOT_FOUND", message: "Resource not found" } },
       404,
     );

--- a/apps/api/src/middleware/security.test.ts
+++ b/apps/api/src/middleware/security.test.ts
@@ -1,78 +1,58 @@
-import type { Context } from "hono";
 import { describe, expect, it, vi } from "vitest";
 
 import { requestSizeLimit } from "./security";
-
-const createMockContext = (options: { headers?: Record<string, string> } = {}) => {
-  const { headers = {} } = options;
-  const variables = new Map<string, unknown>();
-
-  return {
-    get: vi.fn((key: string) => variables.get(key)),
-    header: vi.fn(),
-    json: vi.fn((body: unknown, status?: number) => ({ body, status })),
-    req: {
-      header: vi.fn((name: string) => headers[name]),
-      method: "GET",
-      path: "/test",
-      url: "http://localhost/test",
-    },
-    set: vi.fn((key: string, value: unknown) => {
-      variables.set(key, value);
-    }),
-  } as unknown as Context & { json: ReturnType<typeof vi.fn> };
-};
+import { createMockContext } from "./test-helpers";
 
 describe("requestSizeLimit", () => {
   const next = vi.fn();
 
-  it("should reject requests exceeding max size", async () => {
+  it("rejects requests exceeding max size", async () => {
     const middleware = requestSizeLimit(1024);
-    const c = createMockContext({ headers: { "content-length": "2048" } });
+    const { ctx, mocks } = createMockContext({ headers: { "content-length": "2048" } });
 
-    await middleware(c, next);
+    await middleware(ctx, next);
 
-    expect(c.json).toHaveBeenCalledWith(
+    expect(mocks.json).toHaveBeenCalledWith(
       { error: { code: "PAYLOAD_TOO_LARGE", message: "Request entity too large" } },
       413,
     );
     expect(next).not.toHaveBeenCalled();
   });
 
-  it("should pass requests within size limit", async () => {
+  it("passes requests within size limit", async () => {
     const middleware = requestSizeLimit(1024);
-    const c = createMockContext({ headers: { "content-length": "512" } });
+    const { ctx } = createMockContext({ headers: { "content-length": "512" } });
 
-    await middleware(c, next);
+    await middleware(ctx, next);
 
     expect(next).toHaveBeenCalled();
   });
 
-  it("should pass requests with no content-length header", async () => {
+  it("passes requests with no content-length header", async () => {
     const middleware = requestSizeLimit(1024);
-    const c = createMockContext();
+    const { ctx } = createMockContext();
 
-    await middleware(c, next);
-
-    expect(next).toHaveBeenCalled();
-  });
-
-  it("should use default 10MB limit when no argument provided", async () => {
-    const middleware = requestSizeLimit();
-    const c = createMockContext({ headers: { "content-length": "5000000" } });
-
-    await middleware(c, next);
+    await middleware(ctx, next);
 
     expect(next).toHaveBeenCalled();
   });
 
-  it("should reject when exceeding default 10MB limit", async () => {
+  it("uses default 10MB limit when no argument provided", async () => {
     const middleware = requestSizeLimit();
-    const c = createMockContext({ headers: { "content-length": "20000000" } });
+    const { ctx } = createMockContext({ headers: { "content-length": "5000000" } });
 
-    await middleware(c, next);
+    await middleware(ctx, next);
 
-    expect(c.json).toHaveBeenCalledWith(
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("rejects when exceeding default 10MB limit", async () => {
+    const middleware = requestSizeLimit();
+    const { ctx, mocks } = createMockContext({ headers: { "content-length": "20000000" } });
+
+    await middleware(ctx, next);
+
+    expect(mocks.json).toHaveBeenCalledWith(
       { error: { code: "PAYLOAD_TOO_LARGE", message: "Request entity too large" } },
       413,
     );

--- a/apps/api/src/middleware/test-helpers.ts
+++ b/apps/api/src/middleware/test-helpers.ts
@@ -1,0 +1,56 @@
+import type { Context } from "hono";
+import { vi } from "vitest";
+
+type CreateMockContextOptions = {
+  headers?: Record<string, string>;
+  variables?: Record<string, unknown>;
+};
+
+export type MockContextMocks = {
+  body: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
+  header: ReturnType<typeof vi.fn>;
+  json: ReturnType<typeof vi.fn>;
+  loggerError: ReturnType<typeof vi.fn>;
+  loggerInfo: ReturnType<typeof vi.fn>;
+  reqHeader: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+};
+
+// One cast is unavoidable because Hono's Context surface is too large
+// to fully mock; consolidating to one helper means test files stay cast-free.
+export const createMockContext = (
+  opts: CreateMockContextOptions = {},
+): { ctx: Context; mocks: MockContextMocks } => {
+  const variables = new Map<string, unknown>(Object.entries(opts.variables ?? {}));
+
+  const mocks: MockContextMocks = {
+    body: vi.fn((body: unknown, status?: number) => ({ body, status })),
+    get: vi.fn((key: string) => variables.get(key)),
+    header: vi.fn(),
+    json: vi.fn((body: unknown, status?: number) => ({ body, status })),
+    loggerError: vi.fn(),
+    loggerInfo: vi.fn(),
+    reqHeader: vi.fn((name: string) => opts.headers?.[name]),
+    set: vi.fn((key: string, value: unknown) => {
+      variables.set(key, value);
+    }),
+  };
+
+  const ctx = {
+    body: mocks.body,
+    get: mocks.get,
+    header: mocks.header,
+    json: mocks.json,
+    req: {
+      header: mocks.reqHeader,
+      method: "GET",
+      path: "/test",
+      url: "http://localhost/test",
+    },
+    set: mocks.set,
+    var: { logger: { error: mocks.loggerError, info: mocks.loggerInfo } },
+  } as unknown as Context;
+
+  return { ctx, mocks };
+};

--- a/apps/api/src/middleware/test-helpers.ts
+++ b/apps/api/src/middleware/test-helpers.ts
@@ -7,7 +7,6 @@ type CreateMockContextOptions = {
 };
 
 export type MockContextMocks = {
-  body: ReturnType<typeof vi.fn>;
   get: ReturnType<typeof vi.fn>;
   header: ReturnType<typeof vi.fn>;
   json: ReturnType<typeof vi.fn>;
@@ -25,7 +24,6 @@ export const createMockContext = (
   const variables = new Map<string, unknown>(Object.entries(opts.variables ?? {}));
 
   const mocks: MockContextMocks = {
-    body: vi.fn((body: unknown, status?: number) => ({ body, status })),
     get: vi.fn((key: string) => variables.get(key)),
     header: vi.fn(),
     json: vi.fn((body: unknown, status?: number) => ({ body, status })),
@@ -38,7 +36,6 @@ export const createMockContext = (
   };
 
   const ctx = {
-    body: mocks.body,
     get: mocks.get,
     header: mocks.header,
     json: mocks.json,

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -56,8 +56,8 @@ export const createAuth = (config: AuthConfig) => {
         httpOnly: true,
         sameSite: "lax" as const,
       },
-      // Reverse proxy (portless / Vercel) hides the HTTPS scheme from Better Auth's auto-detection;
-      // gate on WEB_APP_URL instead — unset in CI keeps tests on plain HTTP.
+      // `protocol: "auto"` doesn't reliably detect HTTPS through portless/Vercel reverse proxies;
+      // WEB_APP_URL is the explicit signal. Unset in CI keeps cookies on plain HTTP.
       useSecureCookies: process.env.WEB_APP_URL?.startsWith("https://") === true,
     },
 

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -56,19 +56,8 @@ export const createAuth = (config: AuthConfig) => {
         httpOnly: true,
         sameSite: "lax" as const,
       },
-      // Force the `Secure` cookie flag when WEB_APP_URL is HTTPS. The
-      // dynamic-baseURL `protocol: "auto"` setting documents this as
-      // automatic, but in practice under Next.js + a reverse proxy
-      // (portless in dev, Vercel in prod), Better Auth doesn't reliably
-      // see the HTTPS scheme via `x-forwarded-proto` or `request.url`,
-      // so cookies end up without `Secure`.
-      //
-      // WEB_APP_URL is the explicit signal we already use everywhere:
-      // set to `https://acme.web.localhost` in dev (.env.example) and
-      // `https://app.acme.com` in prod; unset in CI (which runs on
-      // plain http://127.0.0.1) — so the gate naturally avoids the
-      // HTTPS-in-CI footgun that bare `true` or NODE_ENV gating would
-      // re-introduce.
+      // Reverse proxy (portless / Vercel) hides the HTTPS scheme from Better Auth's auto-detection;
+      // gate on WEB_APP_URL instead — unset in CI keeps tests on plain HTTP.
       useSecureCookies: process.env.WEB_APP_URL?.startsWith("https://") === true,
     },
 


### PR DESCRIPTION
## Summary
- New `apps/api/src/middleware/test-helpers.ts` exposes `createMockContext`. Three middleware test files drop their inline mocks and use it; the one remaining `as unknown as Context` cast sits inside the helper.
- Trims the 12-line cookie-Secure block in `packages/auth/src/server.ts` to one sentence on the reverse-proxy edge case.
- Drops the "throwing vs process.exit" defense in `apps/api/src/lib/env.ts`.
- Compresses the optional-auth-middleware parenthetical in `apps/api/src/middleware/auth.ts`.
- Light sweep across api/web/auth for WHAT- and history-shaped comments.

Spec: `docs/superpowers/specs/2026-05-26-deslop-standardization-design.md` (PR C).

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` green
- [x] `pnpm lint` clean
- [x] `git grep "as unknown as" apps/api/src/middleware` → zero matches outside test-helpers.ts
- [ ] CI green on merge