### PR TITLE
fix(transactional): tag emails with stable user.id instead of display name

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -109,6 +109,7 @@ export const createAuth = (config: AuthConfig) => {
                 resetPasswordUrl: `${origin}/recover`,
                 signInUrl: `${origin}/login`,
                 userEmail: user.email,
+                userId: user.id,
                 username: user.name,
               },
               { apiKey: resendApiKey, from: fromEmail },
@@ -138,6 +139,7 @@ export const createAuth = (config: AuthConfig) => {
           {
             resetUrl: url,
             userEmail: user.email,
+            userId: user.id,
             username: user.name,
           },
           { apiKey: resendApiKey, from: fromEmail },
@@ -157,6 +159,7 @@ export const createAuth = (config: AuthConfig) => {
         const result = await sendWelcomeEmail(
           {
             userEmail: user.email,
+            userId: user.id,
             username: user.name,
             verificationUrl: url,
           },
@@ -228,6 +231,7 @@ export const createAuth = (config: AuthConfig) => {
               changeUrl: url,
               currentEmail: user.email,
               newEmail,
+              userId: user.id,
               username: user.name,
             },
             { apiKey: resendApiKey, from: fromEmail },

--- a/packages/transactional/src/lib/senders.ts
+++ b/packages/transactional/src/lib/senders.ts
@@ -20,10 +20,12 @@ const DEFAULT_FROM = "Acme <noreply@acme.com>";
 const sendWelcomeEmail = (
   {
     userEmail,
+    userId,
     username,
     verificationUrl,
   }: {
     userEmail: string;
+    userId: string;
     username?: string;
     verificationUrl: string;
   },
@@ -36,7 +38,7 @@ const sendWelcomeEmail = (
     subject: `Welcome to Acme${username ? `, ${username}` : ""}! Please verify your email`,
     tags: [
       { name: "type", value: "welcome" },
-      ...(username ? [{ name: "username", value: username }] : []),
+      { name: "userId", value: userId },
     ],
     template: React.createElement(WelcomeEmail, {
       userEmail,
@@ -52,11 +54,13 @@ const sendSignUpAttemptEmail = (
     resetPasswordUrl,
     signInUrl,
     userEmail,
+    userId,
     username,
   }: {
     resetPasswordUrl: string;
     signInUrl: string;
     userEmail: string;
+    userId: string;
     username?: string;
   },
   config: EmailConfig,
@@ -68,7 +72,7 @@ const sendSignUpAttemptEmail = (
     subject: "Sign-up attempt with your Acme account",
     tags: [
       { name: "type", value: "sign-up-attempt" },
-      ...(username ? [{ name: "username", value: username }] : []),
+      { name: "userId", value: userId },
     ],
     template: React.createElement(SignUpAttemptEmail, {
       resetPasswordUrl,
@@ -86,12 +90,14 @@ const sendPasswordResetEmail = (
     ipAddress,
     resetUrl,
     userEmail,
+    userId,
     username,
   }: {
     browserInfo?: string;
     ipAddress?: string;
     resetUrl: string;
     userEmail: string;
+    userId: string;
     username?: string;
   },
   config: EmailConfig,
@@ -103,7 +109,7 @@ const sendPasswordResetEmail = (
     subject: "Reset your Acme password",
     tags: [
       { name: "type", value: "password-reset" },
-      ...(username ? [{ name: "username", value: username }] : []),
+      { name: "userId", value: userId },
     ],
     template: React.createElement(PasswordResetEmail, {
       browserInfo,
@@ -121,11 +127,13 @@ const sendChangeEmailConfirmation = (
     changeUrl,
     currentEmail,
     newEmail,
+    userId,
     username,
   }: {
     changeUrl: string;
     currentEmail: string;
     newEmail: string;
+    userId: string;
     username?: string;
   },
   config: EmailConfig,
@@ -137,7 +145,7 @@ const sendChangeEmailConfirmation = (
     subject: "Confirm change of your Acme account email",
     tags: [
       { name: "type", value: "change-email-confirmation" },
-      ...(username ? [{ name: "username", value: username }] : []),
+      { name: "userId", value: userId },
     ],
     template: React.createElement(ChangeEmail, {
       changeUrl,


### PR DESCRIPTION
## Summary

- Resend rejects tag values containing anything outside `[A-Za-z0-9_-]`. We were passing `user.name` (e.g. \`\"Pedro Filho\"\` — has a space) under a `username` tag, breaking verification, sign-up-attempt, password-reset, and change-email flows for any account whose display name contains spaces or punctuation.
- Switch the tag to `userId` carrying `user.id`: opaque, stable across renames, always alphanumeric by Better Auth's adapter, and a more useful analytics key for filtering Resend dashboards.
- The `username` parameter still flows into the email body and subject line (where the display text belongs); only the tag value changes.

## Repro (collabtime, before this pattern was adopted)

\`\`\`
[Better Auth]: Failed to run background task: Error: Failed to send verification email:
Resend failed to queue email: validation_error - Tags should only contain ASCII letters, numbers, underscores, or dashes.
\`\`\`

Account name was \`\"Pedro Filho\"\` — the space in the tag value triggered the rejection.

## Test plan

- [ ] Sign up with a name containing a space → verification email queues; tag visible as \`userId=<cuid>\` in Resend dashboard.
- [ ] Trigger sign-up-attempt (existing email path), password-reset, and change-email → all queue.
- [ ] Existing analytics filters by `username` tag will need to migrate to `userId` (no production analytics dashboards depend on this today).

## Related

This is the template change. Will propagate to easeia, localcine, collabtime, frow in follow-up PRs (collabtime already has belt-and-suspenders tag sanitization from #120 which stays as defense-in-depth).