### PR TITLE
fix(build): order db:generate before build in turbo task graph

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
   "globalEnv": ["NODE_ENV"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "db:generate"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"],
       "env": [
         "API_URL",


### PR DESCRIPTION
## Summary

Preventive fix. Aligns with [frow-monorepo PR #211](https://github.com/unlockers-io/frow-monorepo/pull/211) and [collabtime-monorepo PR #124](https://github.com/unlockers-io/collabtime-monorepo/pull/124).

`@repo/db` re-exports the Prisma client from `src/generated`, produced by `prisma generate`. With only `dependsOn: ["^build"]`, turbo could cache-hit `@repo/db`'s build — replaying logs without re-running `prisma generate`. Combined with Vercel restoring a `node_modules` cache where `pnpm install` says "Already up to date" and skips `postinstall: db:generate`, `src/generated/` ends up empty, and Turbopack can't resolve `./generated/client` in `@repo/web`. Collabtime broke production on this exact trap today.

`db:generate` already has `cache: false`, so adding it to the build task's `dependsOn` guarantees a fresh `prisma generate` runs before any consuming build.

## Test plan

- [x] Local `pnpm typecheck` clean
- [x] Local `pnpm lint` clean
- [ ] Vercel preview build succeeds
- [ ] Production deploy succeeds after merge