### PR TITLE
fix(transactional): accept 'Display Name <email>' in sendEmail from/replyTo

### DIFF
--- a/packages/transactional/src/lib/send-email.test.ts
+++ b/packages/transactional/src/lib/send-email.test.ts
@@ -1,0 +1,75 @@
+import { createElement } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMock = vi.fn();
+vi.mock("resend", () => ({
+  Resend: class {
+    emails = { send: sendMock };
+  },
+}));
+
+const { sendEmail } = await import("./send-email");
+
+describe("sendEmail from validation", () => {
+  beforeEach(() => {
+    sendMock.mockReset();
+    sendMock.mockResolvedValue({ data: { id: "test" }, error: null });
+  });
+
+  const template = createElement("div", null, "hi");
+
+  it('accepts "Display Name <email>" form in from', async () => {
+    const result = await sendEmail({
+      apiKey: "re_test",
+      from: "Acme <noreply@acme.com>",
+      subject: "x",
+      template,
+      to: "delivered+test@resend.dev",
+    });
+
+    expect(result.success).toBe(true);
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(sendMock.mock.calls[0][0]).toMatchObject({
+      from: "Acme <noreply@acme.com>",
+    });
+  });
+
+  it("accepts bare email in from", async () => {
+    const result = await sendEmail({
+      apiKey: "re_test",
+      from: "noreply@acme.com",
+      subject: "x",
+      template,
+      to: "delivered+test@resend.dev",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("falls back to default wrapped sender when from is omitted", async () => {
+    const result = await sendEmail({
+      apiKey: "re_test",
+      subject: "x",
+      template,
+      to: "delivered+test@resend.dev",
+    });
+
+    expect(result.success).toBe(true);
+    expect(sendMock.mock.calls[0][0]).toMatchObject({
+      from: "Acme <noreply@acme.com>",
+    });
+  });
+
+  it("rejects from values that are neither bare email nor wrapped form", async () => {
+    const result = await sendEmail({
+      apiKey: "re_test",
+      from: "not-an-email",
+      subject: "x",
+      template,
+      to: "delivered+test@resend.dev",
+    });
+
+    expect(result.success).toBe(false);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/transactional/src/lib/send-email.ts
+++ b/packages/transactional/src/lib/send-email.ts
@@ -3,11 +3,25 @@ import { render } from "react-email";
 import { Resend } from "resend";
 import { z } from "zod";
 
+// Resend accepts either a bare email or RFC 5322 "Display Name <email>" form
+// for from / reply-to. `z.string().email()` only matches bare addresses, so
+// extract the bracketed address when present and validate that. The default
+// for `from` also uses the wrapped form to surface a friendly display name
+// in inboxes, so the validator has to accept it.
+const senderAddressSchema = z.string().refine(
+  (val) => {
+    const wrapped = val.match(/^.+<([^<>\s]+)>$/v);
+    const email = wrapped ? wrapped[1] : val;
+    return z.email().safeParse(email).success;
+  },
+  { message: "Must be a valid email or 'Display Name <email>' format" },
+);
+
 const emailConfigSchema = z.object({
   bcc: z.union([z.string().email(), z.array(z.string().email())]).optional(),
   cc: z.union([z.string().email(), z.array(z.string().email())]).optional(),
-  from: z.string().email().default("Acme <noreply@acme.com>"),
-  replyTo: z.string().email().optional(),
+  from: senderAddressSchema.default("Acme <noreply@acme.com>"),
+  replyTo: senderAddressSchema.optional(),
   subject: z.string(),
   tags: z
     .array(
@@ -20,7 +34,10 @@ const emailConfigSchema = z.object({
   to: z.union([z.string().email(), z.array(z.string().email())]),
 });
 
-type EmailConfig = z.infer<typeof emailConfigSchema>;
+// z.input keeps `from` optional for callers — the Zod default fills it in
+// during parse. Using z.infer (the output type) would require every caller
+// to pass `from`, defeating the default.
+type EmailConfig = z.input<typeof emailConfigSchema>;
 
 type SendEmailOptions = EmailConfig & {
   apiKey: string;


### PR DESCRIPTION
## Summary
- Mirrors collabtime PR #127. Without this fix, any caller passing a wrapped \`"Display Name <email>"\` value to \`sendEmail\` (matching the schema's own default) gets a Zod validation failure — \`sendVerificationEmail\` throws, Better Auth's enumeration-prevention path swallows it, signups complete but no email ever leaves.
- Replaces \`z.string().email()\` for \`from\` / \`replyTo\` with a refinement that accepts either bare addresses or the RFC 5322 wrapped form.
- Switches \`EmailConfig\` to \`z.input\` so callers can omit \`from\` and let the schema default fill it in.

## Test plan
- [x] \`pnpm test\` — 4 new send-email validation tests pass
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean