### PR TITLE
test(e2e): assert auth emails actually leave Resend

### DIFF
--- a/tests/e2e/auth-email/change-email.spec.ts
+++ b/tests/e2e/auth-email/change-email.spec.ts
@@ -3,12 +3,13 @@ import { prisma } from "@repo/db";
 
 import { webUrl } from "../../../playwright.config";
 import { verification } from "../fixtures/verification.fixture";
+import { extractLink, waitForEmail } from "../helpers/resend";
 import { makeTestEmail, makeTestUsername } from "../helpers/test-email";
 
 test.skip(!process.env.RESEND_API_KEY, "needs RESEND_API_KEY (test mode)");
 
 test.describe("Change email (two-stage confirmation + verification)", () => {
-  test("user changes email to a new address and signs in with the new one", async ({
+  test("user changes email — both stage-1 and stage-2 mails leave Resend, new email signs in", async ({
     page,
     request,
   }, testInfo) => {
@@ -19,7 +20,8 @@ test.describe("Change email (two-stage confirmation + verification)", () => {
     const username = makeTestUsername(currentEmail);
     const password = "ChangeEmailPwd1!";
 
-    // Seed + verify a user, then sign in to get a session.
+    // Seed + verify a user, then sign in to get a session. Welcome email isn't
+    // under test here; reuse the JWT-reconstruction path.
     const signUp = await request.post(`${webUrl}/api/auth/sign-up/email`, {
       data: { email: currentEmail, name: "Change Me", password, username },
     });
@@ -32,25 +34,40 @@ test.describe("Change email (two-stage confirmation + verification)", () => {
     const cookies = await page.context().cookies();
     const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
 
+    const since = Date.now();
+
     const change = await request.post(`${webUrl}/api/auth/change-email`, {
       data: { newEmail },
       headers: { Cookie: cookieHeader },
     });
     expect(change.status()).toBe(200);
 
-    const { confirmationUrl, verificationUrl } = await verification.forChangeEmail(
-      currentEmail,
-      newEmail,
-    );
+    // Stage 1 — current-mailbox owner consents. Assert the confirmation
+    // email landed in Resend's outbox before following it.
+    const stage1Mail = await waitForEmail({
+      sinceMs: since,
+      subject: /confirm|change/i,
+      to: currentEmail,
+    });
+    expect(stage1Mail.last_event).not.toBe("bounced");
+    const stage1Url = extractLink(stage1Mail, /\/api\/auth\/verify-email\?token=/v);
 
-    // Stage 1 — current-mailbox owner consents. Better Auth's verify-email
-    // handler issues stage-2 internally and redirects to callbackURL.
-    await page.goto(confirmationUrl);
+    // Stage-1 click — Better Auth's verify-email handler issues stage-2
+    // internally (sent to newEmail) and redirects to callbackURL.
+    await page.goto(stage1Url);
     await page.waitForURL("/dashboard");
 
-    // Stage 2 — new-mailbox owner proves access. This is the call that
+    // Stage 2 — assert the verification mail to the NEW address actually sent.
+    const stage2Mail = await waitForEmail({
+      sinceMs: since,
+      to: newEmail,
+    });
+    expect(stage2Mail.last_event).not.toBe("bounced");
+    const stage2Url = extractLink(stage2Mail, /\/api\/auth\/verify-email\?token=/v);
+
+    // Stage-2 click — proves new-mailbox access. This is the call that
     // actually updates the user record.
-    await page.goto(verificationUrl);
+    await page.goto(stage2Url);
     await page.waitForURL("/dashboard");
 
     // DB now reflects the new email. The user row count is unchanged.

--- a/tests/e2e/auth-email/existing-user-signup.spec.ts
+++ b/tests/e2e/auth-email/existing-user-signup.spec.ts
@@ -2,12 +2,13 @@ import { expect, test } from "@playwright/test";
 import { prisma } from "@repo/db";
 
 import { webUrl } from "../../../playwright.config";
+import { waitForEmail } from "../helpers/resend";
 import { makeTestEmail, makeTestUsername } from "../helpers/test-email";
 
 test.skip(!process.env.RESEND_API_KEY, "needs RESEND_API_KEY (test mode)");
 
 test.describe("Sign-up for an existing email (enumeration prevention)", () => {
-  test("second signup returns synthetic success without creating a duplicate", async ({
+  test("second signup returns synthetic success, notifies the real account holder, no duplicate row", async ({
     page,
     request,
   }, testInfo) => {
@@ -21,10 +22,14 @@ test.describe("Sign-up for an existing email (enumeration prevention)", () => {
     });
     expect([200, 201]).toContain(first.status());
 
+    // Pin AFTER the first signup so the welcome mail doesn't match the
+    // sign-up-attempt assertion below.
+    const since = Date.now();
+
     // Second sign-up with same email — Better Auth's enumeration-prevention
-    // returns the same shape as a fresh signup; onExistingUserSignUp fires
-    // server-side. The test verifies the *contract* (no error, same status
-    // class) and the *side-effect ceiling* (no duplicate row).
+    // returns the same shape as a fresh signup; `onExistingUserSignUp` fires
+    // server-side and dispatches a "someone tried to sign up" notification
+    // to the real account holder.
     const second = await request.post(`${webUrl}/api/auth/sign-up/email`, {
       data: {
         email,
@@ -35,11 +40,19 @@ test.describe("Sign-up for an existing email (enumeration prevention)", () => {
     });
     expect([200, 201]).toContain(second.status());
 
-    // Exactly one user with that email. Better Auth's email field is unique
-    // at the schema level too, but asserting here pins behavior: the synthetic
-    // success path must NEVER write a second row, even by mistake.
+    // Side-effect ceiling: exactly one user row.
     const users = await prisma.user.findMany({ where: { email } });
     expect(users).toHaveLength(1);
     expect(users[0]?.name).toBe("Original Name");
+
+    // Side-effect floor: the notification email actually went out via Resend.
+    // Without this assertion, a regression that disabled the hook would pass
+    // the test silently — exactly the bug class we're trying to catch.
+    const mail = await waitForEmail({
+      sinceMs: since,
+      subject: /sign[\s-]?up|attempt|tried/i,
+      to: email,
+    });
+    expect(mail.last_event).not.toBe("bounced");
   });
 });

--- a/tests/e2e/auth-email/password-reset.spec.ts
+++ b/tests/e2e/auth-email/password-reset.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import { webUrl } from "../../../playwright.config";
 import { verification } from "../fixtures/verification.fixture";
+import { extractLink, waitForEmail } from "../helpers/resend";
 import { makeTestEmail, makeTestUsername } from "../helpers/test-email";
 
 test.skip(!process.env.RESEND_API_KEY, "needs RESEND_API_KEY (test mode)");
@@ -18,9 +19,9 @@ test.describe("Password reset", () => {
     const originalPassword = "OriginalPassword1!";
     const newPassword = "BrandNewPassword2!";
 
-    // Seed a user via the API. Bypass verification by visiting the verify URL
-    // directly — the reset flow itself doesn't require verified status, but a
-    // user that exists.
+    // Seed a user via the API. Bypass verification with the JWT-reconstruction
+    // helper — delivery of the *welcome* email isn't under test here. (See
+    // sign-up-verification.spec.ts for that assertion.)
     const signUp = await request.post(`${webUrl}/api/auth/sign-up/email`, {
       data: { email, name: "Reset Me", password: originalPassword, username },
     });
@@ -28,6 +29,10 @@ test.describe("Password reset", () => {
     const verify = await verification.forVerifyEmail(email);
     await page.goto(verify.url);
     await page.context().clearCookies();
+
+    // Pin the cutoff AFTER the welcome email was sent so we don't pick it up
+    // when looking for the password-reset mail.
+    const since = Date.now();
 
     // Request reset. Better Auth's endpoint is `/request-password-reset`
     // (the older `/forget-password` path was removed). Always returns 200
@@ -37,10 +42,19 @@ test.describe("Password reset", () => {
     });
     expect(reset.status()).toBe(200);
 
-    const { url } = await verification.forResetPassword(email);
-    await page.goto(url);
+    // Assert the reset email actually left Resend — this is the bug class
+    // "we sent a 200 but never delivered" that the old DB-poll path missed.
+    const mail = await waitForEmail({
+      sinceMs: since,
+      subject: /reset/i,
+      to: email,
+    });
+    expect(mail.last_event).not.toBe("bounced");
 
-    // The reset page reads token from query. fill new password.
+    const resetUrl = extractLink(mail, /\/reset-password\?token=/v);
+    await page.goto(resetUrl);
+
+    // The reset page reads token from query. Fill new password.
     await page.getByLabel("New password", { exact: true }).fill(newPassword);
     await page.getByLabel(/confirm password/i).fill(newPassword);
     await page.getByRole("button", { name: /reset password/i }).click();

--- a/tests/e2e/auth-email/sign-up-verification.spec.ts
+++ b/tests/e2e/auth-email/sign-up-verification.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { webUrl } from "../../../playwright.config";
-import { verification } from "../fixtures/verification.fixture";
+import { extractLink, waitForEmail } from "../helpers/resend";
 import { makeTestEmail, makeTestUsername } from "../helpers/test-email";
 
 // Skip the whole suite when Resend isn't configured. Without RESEND_API_KEY,
@@ -10,10 +10,11 @@ import { makeTestEmail, makeTestUsername } from "../helpers/test-email";
 test.skip(!process.env.RESEND_API_KEY, "needs RESEND_API_KEY (test mode)");
 
 test.describe("Sign-up email verification", () => {
-  test("verify link lands on success page; original tab signs in via polling", async ({
+  test("verify email is sent, link verifies the user, sign-in then succeeds", async ({
     browser,
     request,
   }, testInfo) => {
+    const since = Date.now();
     const email = makeTestEmail(testInfo);
     const username = makeTestUsername(email);
     const password = "SecurePassword1!";
@@ -31,14 +32,25 @@ test.describe("Sign-up email verification", () => {
     });
     expect(preSignIn.status()).not.toBe(200);
 
-    // Cross-device: click the verify URL in a fresh BrowserContext (no
-    // shared cookies). With autoSignInAfterVerification: false, this lands
-    // on the success page WITHOUT creating a session in this context — the
-    // polling tab elsewhere is the one that completes sign-in.
+    // Assert the verification email actually left Resend. This is the
+    // regression we care about: "JWT format was valid but the email never
+    // sent" silently passed the old reconstruction-based path.
+    const mail = await waitForEmail({
+      sinceMs: since,
+      subject: /verify/i,
+      to: email,
+    });
+    expect(mail.last_event).not.toBe("bounced");
+
+    // Pull the verification URL out of the rendered HTML and follow it in a
+    // fresh BrowserContext (cross-device click). With
+    // autoSignInAfterVerification: false, this lands on the success page
+    // WITHOUT creating a session in the clicker context — the polling tab
+    // elsewhere is the one that completes sign-in.
+    const verifyUrl = extractLink(mail, /\/api\/auth\/verify-email\?token=/v);
     const clickerContext = await browser.newContext();
     const clickerPage = await clickerContext.newPage();
-    const { url } = await verification.forVerifyEmail(email);
-    await clickerPage.goto(url);
+    await clickerPage.goto(verifyUrl);
     await expect(clickerPage).toHaveURL(/\/verify-email\/success$/v);
     await expect(clickerPage.getByRole("heading", { name: "Email verified" })).toBeVisible();
     const clickerCookies = await clickerContext.cookies(webUrl);

--- a/tests/e2e/helpers/resend.ts
+++ b/tests/e2e/helpers/resend.ts
@@ -1,0 +1,164 @@
+// Resend test-inbox client used by the auth-email specs to assert that
+// transactional emails were actually sent (and not silently dropped by a
+// regressed sender, missing API key, schema-validation rejection, etc.).
+//
+// Why poll the live API instead of reconstructing JWTs locally:
+// reconstruction proves the token format is correct, but says NOTHING about
+// whether the email left our infrastructure. We've been bitten by that —
+// "the JWT was valid but the email never sent" is the bug class this helper
+// catches. The JWT/DB-poll path in `verification.fixture.ts` remains useful
+// for tests where delivery isn't under test (e.g. seeding a verified user
+// before a different scenario).
+//
+// All sends in e2e use `delivered+<label>@resend.dev` (see helpers/test-email.ts).
+// Resend short-circuits delivery for these addresses but still records the
+// send in the API, so `GET /emails` lists them in test-mode runs.
+
+const RESEND_API = "https://api.resend.com";
+
+type ResendListItem = {
+  bcc: string | null;
+  cc: string | null;
+  created_at: string;
+  from: string;
+  id: string;
+  last_event: string;
+  reply_to: string | null;
+  scheduled_at: string | null;
+  subject: string;
+  to: Array<string>;
+};
+
+type ResendEmail = ResendListItem & {
+  html: string | null;
+  object: "email";
+  tags: Array<{ name: string; value: string }> | null;
+  text: string | null;
+};
+
+const requireApiKey = (): string => {
+  const key = process.env.RESEND_API_KEY;
+  if (!key) {
+    throw new Error(
+      "RESEND_API_KEY is required for the Resend e2e helper. " +
+        "Specs that depend on delivery assertions should `test.skip` themselves " +
+        "with `test.skip(!process.env.RESEND_API_KEY, ...)`.",
+    );
+  }
+  return key;
+};
+
+const resendFetch = async (path: string): Promise<Response> => {
+  const response = await fetch(`${RESEND_API}${path}`, {
+    headers: { Authorization: `Bearer ${requireApiKey()}` },
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => "<unreadable>");
+    throw new Error(`Resend ${path} → ${response.status}: ${body}`);
+  }
+  return response;
+};
+
+const listEmails = async (limit = 100): Promise<Array<ResendListItem>> => {
+  const response = await resendFetch(`/emails?limit=${limit}`);
+  const body = (await response.json()) as { data?: Array<ResendListItem> };
+  return body.data ?? [];
+};
+
+const getEmail = async (id: string): Promise<ResendEmail> => {
+  const response = await resendFetch(`/emails/${id}`);
+  return (await response.json()) as ResendEmail;
+};
+
+type WaitForEmailOptions = {
+  // Only match emails created at or after this Unix-ms timestamp. Pin to
+  // `Date.now()` at the start of a test so prior runs' mails don't match.
+  sinceMs: number;
+  subject?: RegExp;
+  // Address that must appear in `to[]`. Case-insensitive.
+  to: string;
+};
+
+type WaitForOptions = {
+  // ms — Resend's index is eventually consistent; in practice mails
+  // become listable within a few seconds, but CI cold starts can stretch.
+  pollMs?: number;
+  timeoutMs?: number;
+};
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+// Polls `GET /emails` until a matching message appears, then fetches its
+// HTML body via `GET /emails/:id`. Throws if the deadline elapses with no
+// match — the caller's spec should fail loudly so the email regression
+// surfaces, rather than time out into a misleading downstream error.
+const waitForEmail = async (
+  match: WaitForEmailOptions,
+  options: WaitForOptions = {},
+): Promise<ResendEmail> => {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const pollMs = options.pollMs ?? 1000;
+  const target = match.to.toLowerCase();
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    // eslint-disable-next-line no-await-in-loop
+    const recent = await listEmails(100);
+
+    const candidate = recent.find((mail) => {
+      const created = Date.parse(mail.created_at);
+      if (Number.isNaN(created) || created < match.sinceMs) {
+        return false;
+      }
+      if (!mail.to.some((addr) => addr.toLowerCase() === target)) {
+        return false;
+      }
+      if (match.subject && !match.subject.test(mail.subject)) {
+        return false;
+      }
+      return true;
+    });
+
+    if (candidate) {
+      // eslint-disable-next-line no-await-in-loop
+      return await getEmail(candidate.id);
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(pollMs);
+  }
+
+  const subjectClause = match.subject ? ` matching ${match.subject}` : "";
+  throw new Error(
+    `waitForEmail: no email to ${match.to}${subjectClause} within ${timeoutMs}ms — check the auth send-hook actually executed.`,
+  );
+};
+
+// Pulls the first href matching `pattern` out of the email's HTML body.
+// Falls back to the text body if HTML is empty (some templates render text-only).
+const extractLink = (email: ResendEmail, pattern: RegExp): string => {
+  const haystack = email.html ?? email.text ?? "";
+  // Match an href="..." attribute whose URL satisfies the pattern.
+  const hrefMatches = haystack.matchAll(/href="([^"]+)"/gv);
+  for (const [, href] of hrefMatches) {
+    const decoded = href.replaceAll("&amp;", "&");
+    if (pattern.test(decoded)) {
+      return decoded;
+    }
+  }
+  // Plain-text fallback — look for the bare URL.
+  const direct = haystack.match(pattern);
+  if (direct) {
+    return direct[0];
+  }
+  throw new Error(
+    `extractLink: no URL matching ${pattern} in email ${email.id} ` +
+      `(subject: "${email.subject}"). Body length: ${haystack.length}.`,
+  );
+};
+
+export { extractLink, getEmail, listEmails, waitForEmail };
+export type { ResendEmail, ResendListItem };

--- a/tests/e2e/helpers/resend.ts
+++ b/tests/e2e/helpers/resend.ts
@@ -16,6 +16,11 @@
 
 const RESEND_API = "https://api.resend.com";
 
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
 type ResendListItem = {
   bcc: string | null;
   cc: string | null;
@@ -48,15 +53,65 @@ const requireApiKey = (): string => {
   return key;
 };
 
+// Resend caps the team at 5 req/s and returns 429 with a `retry-after`
+// header (seconds) when the suite bursts past that. Parallel auth-email
+// specs reliably trip it — every test polls `GET /emails` at 1Hz, so 4
+// workers × spec startup hits the ceiling. Mirrors vercel/fetch-retry's
+// defaults (factor 6, 5 retries, max retry-after 20s) so behavior matches
+// the most-deployed reference for this pattern. See
+// https://resend.com/docs/api-reference/rate-limit and
+// https://github.com/vercel/fetch-retry/blob/master/index.js.
+const RETRY_MAX_ATTEMPTS = 5;
+const RETRY_MAX_RETRY_AFTER_SECONDS = 20;
+const RETRY_BASE_MS = 200;
+const RETRY_FACTOR = 6;
+const RETRY_JITTER_MS = 100;
+
+const computeBackoffMs = (attempt: number): number => {
+  // 200, 1200, 7200, 43200, … capped at MAX_RETRY_AFTER. Adds ±0–100ms
+  // jitter so a stampede of clients doesn't re-synchronize.
+  const base = Math.min(
+    RETRY_BASE_MS * RETRY_FACTOR ** attempt,
+    RETRY_MAX_RETRY_AFTER_SECONDS * 1000,
+  );
+  return base + Math.floor(Math.random() * RETRY_JITTER_MS);
+};
+
+const isRetryableStatus = (status: number): boolean =>
+  status === 429 || (status >= 500 && status < 600);
+
 const resendFetch = async (path: string): Promise<Response> => {
-  const response = await fetch(`${RESEND_API}${path}`, {
-    headers: { Authorization: `Bearer ${requireApiKey()}` },
-  });
-  if (!response.ok) {
-    const body = await response.text().catch(() => "<unreadable>");
-    throw new Error(`Resend ${path} → ${response.status}: ${body}`);
+  const url = `${RESEND_API}${path}`;
+  const headers = { Authorization: `Bearer ${requireApiKey()}` };
+
+  let attempt = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // eslint-disable-next-line no-await-in-loop
+    const response = await fetch(url, { headers });
+
+    if (!isRetryableStatus(response.status) || attempt >= RETRY_MAX_ATTEMPTS) {
+      if (!response.ok) {
+        // eslint-disable-next-line no-await-in-loop
+        const body = await response.text().catch(() => "<unreadable>");
+        throw new Error(`Resend ${path} → ${response.status}: ${body}`);
+      }
+      return response;
+    }
+
+    // Honor server-suggested wait when present (Resend sends `retry-after`
+    // in seconds — never an HTTP-date for this API). Fall back to
+    // exponential backoff for 5xx or odd 429s without the header.
+    const retryAfter = Number.parseInt(response.headers.get("retry-after") ?? "", 10);
+    const delayMs = Number.isFinite(retryAfter)
+      ? Math.min(retryAfter, RETRY_MAX_RETRY_AFTER_SECONDS) * 1000 +
+        Math.floor(Math.random() * RETRY_JITTER_MS)
+      : computeBackoffMs(attempt);
+
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(delayMs);
+    attempt += 1;
   }
-  return response;
 };
 
 const listEmails = async (limit = 100): Promise<Array<ResendListItem>> => {
@@ -85,11 +140,6 @@ type WaitForOptions = {
   pollMs?: number;
   timeoutMs?: number;
 };
-
-const sleep = (ms: number) =>
-  new Promise<void>((resolve) => {
-    setTimeout(resolve, ms);
-  });
 
 // Polls `GET /emails` until a matching message appears, then fetches its
 // HTML body via `GET /emails/:id`. Throws if the deadline elapses with no


### PR DESCRIPTION
## Summary

- Adds a Resend-API polling helper (`tests/e2e/helpers/resend.ts`) and updates the four `auth-email/` specs to call it.
- Catches an email regression class the old JWT-reconstruction path silently masked: "send hook returned 200 but the email was never queued."
- Pure additive — the `verification.fixture.ts` JWT/DB-poll path still ships and is still used for tests that only need to seed a verified user.

Why this matters: we've shipped at least three bugs in the last two months where an auth email validator rejected the payload and the send hook silently swallowed the error. The old test suite reconstructed the verify-email JWT in-process and clicked it — the token was valid, the test passed, but in production no email ever sent. Polling `GET /emails` for the actual record is the deterministic check.

## Behavior changes

Each affected spec now `waitForEmail()`s on Resend's `GET /emails` until a matching message lands, then `extractLink()`s the verification URL out of the rendered HTML and follows it:

- `sign-up-verification.spec.ts` — asserts the welcome/verify email lands; clicks the URL from the email (not from JWT reconstruction).
- `password-reset.spec.ts` — asserts the reset email lands; clicks the URL from the email.
- `change-email.spec.ts` — asserts BOTH stage-1 (consent to current address) AND stage-2 (verification to new address) leave Resend before continuing.
- `existing-user-signup.spec.ts` — asserts the "someone tried to sign up with your email" notification fires (this hook had no test coverage before — a regression that disabled it would have passed the suite silently).

Specs all `test.skip(!process.env.RESEND_API_KEY, ...)` so they're a no-op when the key isn't configured (forks, contributors).

## Notes

- Acme has no GitHub Actions, so these run locally and via downstream propagation (next PRs land in easeia/frow/localcine/collabtime, where they actually run in CI).
- The helper uses raw fetch (`Authorization: Bearer ${RESEND_API_KEY}`) — no new dependency.

## Test plan

- [ ] Run `RESEND_API_KEY=re_... pnpm test:e2e -- auth-email` locally; suite passes.
- [ ] Temporarily break one of the send hooks (e.g. comment out `await sendWelcomeEmail(...)`); confirm `sign-up-verification.spec.ts` fails with the "no email to X within 30000ms" message (proves the new assertion catches the bug class).