### PR TITLE
fix(docker): use /var/lib/postgresql mount for PG18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      # Postgres 18 expects the mount at /var/lib/postgresql (major-version subdir lives inside). See docker-library/postgres#1259.
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U acme -d acme"]
       interval: 10s


### PR DESCRIPTION
## Summary

Postgres 18 changed the on-disk layout so the major-version subdir (`18/`) lives inside `/var/lib/postgresql`. Mounting the named volume at `/var/lib/postgresql/data` (the old PG ≤17 convention) puts the volume one level too deep and the entrypoint crashes on startup with messages like:

> PostgreSQL Database directory appears to contain a database; Skipping initialization

…followed by a `PG_VERSION` mismatch.

See docker-library/postgres#1259 for the upstream discussion.

## Fix

Move the volume mount up one level:

```diff
-      - postgres_data:/var/lib/postgresql/data
+      # Postgres 18 expects the mount at /var/lib/postgresql (major-version subdir lives inside). See docker-library/postgres#1259.
+      - postgres_data:/var/lib/postgresql
```

## Heads-up before applying

The existing `postgres_data` named volume still holds data under the old path (`/data`). On first `docker compose up` after this lands, Postgres will start fresh because the mount no longer points at the existing PGDATA. If you need to keep local dev data, dump first; otherwise wiping the volume (`docker compose down -v`) is the cleanest path.

## Test plan

- [ ] `docker compose down -v && docker compose up -d` boots Postgres 18 cleanly
- [ ] `pg_isready` healthcheck reports healthy
- [ ] App connects and migrations run as expected