### PR TITLE
fix(e2e): accept portless self-signed cert locally

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -68,6 +68,8 @@ export default defineConfig({
 
   use: {
     baseURL: webUrl,
+    // Portless serves a self-signed cert locally; CI hits plain HTTP so the toggle scopes the relaxation to the dev environment only.
+    ignoreHTTPSErrors: !process.env.CI,
     screenshot: "only-on-failure",
     trace: "on-first-retry",
     video: "retain-on-failure",


### PR DESCRIPTION
## Summary
- Adds `ignoreHTTPSErrors: !process.env.CI` to the top-level `use` block in `playwright.config.ts`.
- Locally, portless serves `https://acme.web.localhost` with a self-signed cert, which Playwright's APIRequestContext rejects by default — breaking every `request.post()` call in tests.
- In CI the webServers bind to plain `http://127.0.0.1:PORT`, so the toggle is gated on `!process.env.CI` to scope the relaxation strictly to the dev environment.

## Test plan
- [ ] `pnpm exec oxfmt --check playwright.config.ts` passes
- [ ] `pnpm lint` passes
- [ ] Local e2e (portless HTTPS) no longer fails with self-signed cert errors
- [ ] CI e2e behavior unchanged (still hits plain HTTP)