### PR TITLE
fix(e2e): widen password-reset extractLink regex to match Better Auth's URL shape

### DIFF
--- a/tests/e2e/auth-email/password-reset.spec.ts
+++ b/tests/e2e/auth-email/password-reset.spec.ts
@@ -51,7 +51,10 @@ test.describe("Password reset", () => {
     });
     expect(mail.last_event).not.toBe("bounced");
 
-    const resetUrl = extractLink(mail, /\/reset-password\?token=/v);
+    // Better Auth builds `${baseURL}/reset-password/<token>?callbackURL=<redirectTo>`
+    // (token is a path segment, not a query param). The endpoint validates and
+    // redirects to the UI's `/reset-password?token=...`.
+    const resetUrl = extractLink(mail, /\/reset-password\/[^"?]+\?callbackURL=/v);
     await page.goto(resetUrl);
 
     // The reset page reads token from query. Fill new password.


### PR DESCRIPTION
## Summary

- The Resend-driven `password-reset.spec.ts` was failing because the regex `/\/reset-password\?token=/v` doesn't match the URL Better Auth actually puts in the email.
- Better Auth builds `${baseURL}/reset-password/<token>?callbackURL=<redirectTo>` — `token` is a **path segment**, not a query param. The endpoint validates and 302s to the UI's `/reset-password?token=...`.
- Widening to `/\/reset-password\/[^"?]+\?callbackURL=/v` matches reality and stays tight enough to avoid false-positives on the bare UI route.

Verified by reading `node_modules/better-auth/dist/api/routes/password.mjs` line 72: `` const url = `${ctx.context.baseURL}/reset-password/${verificationToken}?callbackURL=${callbackURL}`; ``

## Test plan

- [ ] `pnpm e2e tests/e2e/auth-email/password-reset.spec.ts` passes against a Resend test inbox
- [ ] CI's auth-email matrix is green