### PR TITLE
fix(auth): land verify-email click on /verify-email/success, not /

### DIFF
--- a/apps/web/src/app/(auth)/register/form.tsx
+++ b/apps/web/src/app/(auth)/register/form.tsx
@@ -82,6 +82,12 @@ const RegisterForm = () => {
             throw new Error("Passwords do not match");
           }
           const result = await authClient.signUp.email({
+            // Better Auth builds the verification URL from `body.callbackURL`
+            // (defaulting to "/"), NOT from `emailVerification.callbackURL`
+            // in betterAuth() config — that option is unused by the sign-up
+            // route. Sending the success page explicitly keeps the email
+            // link landing on /verify-email/success instead of /.
+            callbackURL: "/verify-email/success",
             email: value.email,
             name: value.name,
             password: value.password,


### PR DESCRIPTION
## Summary

- Better Auth's sign-up route builds the verification URL from `body.callbackURL` (defaulting to `/`), **not** from `emailVerification.callbackURL` in the `betterAuth()` config — that option is unused by the sign-up code path.
- Result: the email link carried `callbackURL=%2F` and landed users on the home page instead of the sessionless `/verify-email/success` "Email verified, you can close this page" screen.
- Fix: pass `callbackURL: "/verify-email/success"` in the `authClient.signUp.email(...)` call at the form. Mirrors what `pending-screen.tsx` already does on the resend path.

## Why this surfaced now

The Resend-API e2e suite merged earlier today (#106) extracts the verification link from the actual email and clicks it; the previous JWT-reconstruction fixture hardcoded `/verify-email/success` and masked the bug.

## Why this fix (not the alternatives)

- Editing the URL inside `sendVerificationEmail` would be a string-mutation hack hidden in `packages/auth`.
- There is no Better Auth config option for "default sign-up callback" — confirmed by reading `node_modules/better-auth/dist/api/routes/sign-up.mjs` (line 241) and the `EmailVerificationOptions` type in `@better-auth/core`.
- Passing `callbackURL` at the call site mirrors `pending-screen.tsx`'s resend code, keeps the contract visible, and matches the documented orchestrator standard.

## Test plan

- [ ] `e2e/auth-email/email-verification.spec.ts` (Resend-based) now reaches `/verify-email/success` after clicking the email link.
- [ ] Existing `/verify-email/success/page.tsx` renders unchanged ("Email verified, you can close this page").
- [ ] No regression in the verify-email polling screen (it does not use `callbackURL`).

## Propagation

This PR is the **acme template** change; matching PRs land in easeia, frow, localcine, collabtime under the same branch name.