### PR TITLE
chore(e2e): remove ignoreHTTPSErrors

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -68,8 +68,6 @@ export default defineConfig({
 
   use: {
     baseURL: webUrl,
-    // Portless serves a self-signed cert locally; CI hits plain HTTP so the toggle scopes the relaxation to the dev environment only.
-    ignoreHTTPSErrors: !process.env.CI,
     screenshot: "only-on-failure",
     trace: "on-first-retry",
     video: "retain-on-failure",


### PR DESCRIPTION
Reverts the workaround. Portless's self-signed cert should be trusted at the machine level (`NODE_EXTRA_CA_CERTS` in shell profile, or `security add-trusted-cert` on macOS), not by relaxing Playwright's HTTPS verification.