### PR TITLE
fix(e2e): auth-email signup callbackURL + change-email session seed

### DIFF
--- a/tests/e2e/auth-email/change-email.spec.ts
+++ b/tests/e2e/auth-email/change-email.spec.ts
@@ -28,11 +28,26 @@ test.describe("Change email (two-stage confirmation + verification)", () => {
     expect([200, 201]).toContain(signUp.status());
     const verify = await verification.forVerifyEmail(currentEmail);
     await page.goto(verify.url);
-    await page.waitForURL("/dashboard");
+    // forVerifyEmail builds a callbackURL=/verify-email/success URL, and the
+    // verify-email handler runs with autoSignInAfterVerification: false — so
+    // the click lands on /verify-email/success without setting a session
+    // cookie. Sign in explicitly to attach the session for the change-email
+    // request below.
+    await page.waitForURL(/\/verify-email\/success$/v);
+    const signIn = await request.post(`${webUrl}/api/auth/sign-in/email`, {
+      data: { email: currentEmail, password },
+    });
+    expect(signIn.status()).toBe(200);
 
-    // Reuse the existing browser context's session cookie for the API call.
-    const cookies = await page.context().cookies();
-    const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+    // Build the Cookie header from the sign-in response's Set-Cookie headers
+    // (the browser context hasn't received them — we made the call via the
+    // `request` fixture).
+    const setCookie = signIn.headers()["set-cookie"];
+    const cookieHeader =
+      setCookie
+        ?.split(/\n/)
+        .map((c) => c.split(";")[0].trim())
+        .join("; ") ?? "";
 
     const since = Date.now();
 

--- a/tests/e2e/auth-email/sign-up-verification.spec.ts
+++ b/tests/e2e/auth-email/sign-up-verification.spec.ts
@@ -20,7 +20,13 @@ test.describe("Sign-up email verification", () => {
     const password = "SecurePassword1!";
 
     const signUp = await request.post(`${webUrl}/api/auth/sign-up/email`, {
-      data: { email, name: "Verify Me", password, username },
+      data: {
+        callbackURL: "/verify-email/success",
+        email,
+        name: "Verify Me",
+        password,
+        username,
+      },
     });
     expect([200, 201]).toContain(signUp.status());
 


### PR DESCRIPTION
## Summary

Two systemic bugs in the auth-email specs, surfaced by recent local runs:

- **`sign-up-verification.spec`** — raw `POST /api/auth/sign-up/email` was missing `callbackURL: "/verify-email/success"`. Better Auth builds the verify email URL from the body's `callbackURL`; when omitted it defaults to `/`, so the click landed there and the `toHaveURL(/\/verify-email\/success$/v)` assertion timed out. The prod form passes this; the spec bypasses the form via API POST and was missing it.
- **`change-email.spec`** — `forVerifyEmail` builds a URL with `callbackURL=/verify-email/success`, and the handler runs with `autoSignInAfterVerification: false` — so the click lands on the success page without a session cookie. The spec's `waitForURL("/dashboard")` after the seed timed out, AND the subsequent change-email POST would have 401'd. Replace with explicit `POST /api/auth/sign-in/email` and build the Cookie header from the response's Set-Cookie.

The production callbackURL fix already landed in `fix/verify-email-callback-url`; this is the matching e2e-side fix.

## Test plan

- [ ] CI green
- [ ] Trust the static analysis; not running tests locally (slow + Resend env)