### PR TITLE
fix(e2e): forward sign-in cookies + CSRF headers to change-email

### DIFF
--- a/tests/e2e/auth-email/change-email.spec.ts
+++ b/tests/e2e/auth-email/change-email.spec.ts
@@ -39,21 +39,27 @@ test.describe("Change email (two-stage confirmation + verification)", () => {
     });
     expect(signIn.status()).toBe(200);
 
-    // Build the Cookie header from the sign-in response's Set-Cookie headers
-    // (the browser context hasn't received them — we made the call via the
-    // `request` fixture).
-    const setCookie = signIn.headers()["set-cookie"];
-    const cookieHeader =
-      setCookie
-        ?.split(/\n/)
-        .map((c) => c.split(";")[0].trim())
-        .join("; ") ?? "";
+    // Parse Set-Cookie from the sign-in response and forward as Cookie on the
+    // change-email call. Playwright's APIRequestContext storage state doesn't
+    // include cookies set via API responses, so we have to thread the cookie
+    // through manually. Better Auth issues a single `__Secure-<prefix>.
+    // session_token` cookie marked HttpOnly/Secure/SameSite=Lax.
+    const setCookie = signIn.headers()["set-cookie"] ?? "";
+    const cookieHeader = setCookie
+      .split(/,(?=\s*[\w-]+=)/u)
+      .map((c) => c.split(";")[0].trim())
+      .filter(Boolean)
+      .join("; ");
 
     const since = Date.now();
 
     const change = await request.post(`${webUrl}/api/auth/change-email`, {
       data: { newEmail },
-      headers: { Cookie: cookieHeader },
+      headers: {
+        Cookie: cookieHeader,
+        Origin: webUrl,
+        Referer: `${webUrl}/`,
+      },
     });
     expect(change.status()).toBe(200);
 


### PR DESCRIPTION
## Summary

- The `change-email` spec previously parsed `Set-Cookie` from the sign-in response by splitting on `\n`, but Playwright joins multiple `Set-Cookie` values with `, ` — the resulting `Cookie` header was malformed/empty, and the change-email request was effectively unauthenticated.
- Better Auth's `/api/auth/change-email` also enforces CSRF by requiring `Origin` (and we send `Referer`) to match `trustedOrigins`. Without those headers, the request fails CSRF checks even when the cookie is correct.

## Fix

- Parse `Set-Cookie` with a comma-lookahead regex (`/,(?=\s*[\w-]+=)/u`) so multi-cookie responses split correctly.
- Forward `Origin: webUrl` and `Referer: \`${webUrl}/\`` on the change-email POST.

Mirrors the verified fix in collabtime (PR unlockers-io/collabtime-monorepo#135), where the local run came back 4/4 green.

## Test plan

- [ ] CI green on this branch.
- [ ] After merge, run `pnpm exec playwright test tests/e2e/auth-email/change-email.spec.ts` locally and confirm pass (requires `RESEND_API_KEY` + portless dev stack).