### PR TITLE
fix(e2e): seed session cookie into browser context for change-email stage navigation

### DIFF
--- a/tests/e2e/auth-email/change-email.spec.ts
+++ b/tests/e2e/auth-email/change-email.spec.ts
@@ -51,6 +51,32 @@ test.describe("Change email (two-stage confirmation + verification)", () => {
       .filter(Boolean)
       .join("; ");
 
+    // Also seed the session cookie into the browser context so the later
+    // page.goto(stage1Url/stage2Url) calls have an authenticated session
+    // and the proxy doesn't bounce them to /login.
+    const webHost = new URL(webUrl).hostname;
+    const parsedCookies = setCookie
+      .split(/,(?=\s*[\w-]+=)/u)
+      .map((c) => {
+        const [nameValue] = c.split(";");
+        const eq = nameValue.indexOf("=");
+        return { name: nameValue.slice(0, eq).trim(), value: nameValue.slice(eq + 1).trim() };
+      })
+      .filter((c) => c.name);
+    const browserCookies = [];
+    for (const c of parsedCookies) {
+      browserCookies.push({
+        domain: webHost,
+        httpOnly: true,
+        name: c.name,
+        path: "/",
+        sameSite: "Lax" as const,
+        secure: true,
+        value: c.value,
+      });
+    }
+    await page.context().addCookies(browserCookies);
+
     const since = Date.now();
 
     const change = await request.post(`${webUrl}/api/auth/change-email`, {


### PR DESCRIPTION
## Summary

- After signing in via `request.post(/api/auth/sign-in/email)`, the prior fix parses `Set-Cookie` and forwards it as `Cookie` header on the change-email POST (succeeds).
- But the subsequent `page.goto(stage1Url/stage2Url)` navigates with an empty browser cookie jar — Playwright's `APIRequestContext` and `BrowserContext` are separate, so the proxy redirects to `/login`.
- Fix: also seed the parsed cookies into `page.context().addCookies()` before the page.goto calls.

Propagated from localcine PR #257 (validated there + collabtime baseline).

## Test plan

- [ ] CI green