### PR TITLE
fix(template): wire RESEND_API_KEY through web auth + migrate to proxy.ts

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -16,4 +16,4 @@ CORS_ORIGINS=https://acme.web.localhost,https://acme.landing.localhost
 
 # Optional: Resend API for email
 RESEND_API_KEY=
-FROM_EMAIL=noreply@acme.com
+FROM_EMAIL=onboarding@resend.dev

--- a/apps/api/src/lib/env.test.ts
+++ b/apps/api/src/lib/env.test.ts
@@ -23,7 +23,7 @@ describe("envSchema", () => {
       expect(result.data.PORT).toBe("4000");
       expect(result.data.HOST).toBe("0.0.0.0");
       expect(result.data.NODE_ENV).toBe("development");
-      expect(result.data.FROM_EMAIL).toBe("noreply@acme.com");
+      expect(result.data.FROM_EMAIL).toBe("onboarding@resend.dev");
       expect(result.data.CORS_ORIGINS).toBe(
         "https://acme.web.localhost,https://acme.landing.localhost",
       );

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -5,7 +5,7 @@ export const envSchema = z.object({
   BETTER_AUTH_SECRET: z.string().min(32),
   CORS_ORIGINS: z.string().default("https://acme.web.localhost,https://acme.landing.localhost"),
   DATABASE_URL: z.string().min(1),
-  FROM_EMAIL: z.string().default("noreply@acme.com"),
+  FROM_EMAIL: z.string().default("onboarding@resend.dev"),
   HOST: z.string().default("0.0.0.0"),
   NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
   PORT: z.string().default("4000"),

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -21,7 +21,9 @@ export const getAuth = (): Auth => {
     }
     cachedAuth = createAuth({
       extraPlugins: [nextCookies()],
+      fromEmail: process.env.RESEND_FROM_EMAIL ?? "onboarding@resend.dev",
       prisma,
+      resendApiKey: process.env.RESEND_API_KEY,
       secret,
     });
   }

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -7,8 +7,7 @@ const protectedRoutes = ["/dashboard", "/profile", "/settings"];
 
 const authRoutes = ["/login", "/register", "/forgot-password", "/recover", "/reset-password"];
 
-// Named export kept for tests; default export activates Next.js middleware.
-export const middleware = async (request: NextRequest) => {
+export const proxy = async (request: NextRequest) => {
   const pathname = request.nextUrl.pathname;
 
   const isProtectedRoute = protectedRoutes.some((route) => pathname.startsWith(route));
@@ -43,8 +42,6 @@ export const middleware = async (request: NextRequest) => {
 
   return NextResponse.next();
 };
-
-export default middleware;
 
 export const config = {
   matcher: ["/((?!api/auth|_next/static|_next/image|favicon.ico|public).*)"],

--- a/tests/e2e/auth-email/change-email.spec.ts
+++ b/tests/e2e/auth-email/change-email.spec.ts
@@ -8,6 +8,11 @@ import { makeTestEmail, makeTestUsername } from "../helpers/test-email";
 
 test.skip(!process.env.RESEND_API_KEY, "needs RESEND_API_KEY (test mode)");
 
+// auth-email specs seed their own users and bypass the storageState the rest
+// of the suite relies on — they need a clean cookie jar so the signup POST
+// isn't rejected as "already signed in".
+test.use({ storageState: { cookies: [], origins: [] } });
+
 test.describe("Change email (two-stage confirmation + verification)", () => {
   test("user changes email — both stage-1 and stage-2 mails leave Resend, new email signs in", async ({
     page,

--- a/tests/e2e/auth-email/existing-user-signup.spec.ts
+++ b/tests/e2e/auth-email/existing-user-signup.spec.ts
@@ -7,6 +7,8 @@ import { makeTestEmail, makeTestUsername } from "../helpers/test-email";
 
 test.skip(!process.env.RESEND_API_KEY, "needs RESEND_API_KEY (test mode)");
 
+test.use({ storageState: { cookies: [], origins: [] } });
+
 test.describe("Sign-up for an existing email (enumeration prevention)", () => {
   test("second signup returns synthetic success, notifies the real account holder, no duplicate row", async ({
     page,

--- a/tests/e2e/auth-email/password-reset.spec.ts
+++ b/tests/e2e/auth-email/password-reset.spec.ts
@@ -7,6 +7,8 @@ import { makeTestEmail, makeTestUsername } from "../helpers/test-email";
 
 test.skip(!process.env.RESEND_API_KEY, "needs RESEND_API_KEY (test mode)");
 
+test.use({ storageState: { cookies: [], origins: [] } });
+
 test.describe("Password reset", () => {
   test("user can request reset, set a new password, and sign in", async ({
     page,

--- a/tests/e2e/auth-email/sign-up-verification.spec.ts
+++ b/tests/e2e/auth-email/sign-up-verification.spec.ts
@@ -9,6 +9,8 @@ import { makeTestEmail, makeTestUsername } from "../helpers/test-email";
 // different code path — these tests would assert against the wrong behavior.
 test.skip(!process.env.RESEND_API_KEY, "needs RESEND_API_KEY (test mode)");
 
+test.use({ storageState: { cookies: [], origins: [] } });
+
 test.describe("Sign-up email verification", () => {
   test("verify email is sent, link verifies the user, sign-in then succeeds", async ({
     browser,

--- a/tests/e2e/helpers/test-email.ts
+++ b/tests/e2e/helpers/test-email.ts
@@ -12,11 +12,13 @@ const makeTestEmail = (info: TestInfo): string => {
 };
 
 // Better Auth's `username()` plugin makes username effectively required at
-// signup. Default validator is /^[a-zA-Z0-9_.]+$/ (see better-auth/plugins/
-// username/index.mjs:defaultUsernameValidator) — dashes are NOT allowed,
-// so the slug uses underscores. Derive from the test email to stay
-// unique-per-run and traceable back to the spec.
-const makeTestUsername = (email: string): string =>
-  `e2e_${email.split("@")[0].replaceAll(/\W/g, "_").slice(0, 30)}`;
+// signup. Default validator is /^[a-zA-Z0-9_.]+$/ (dashes rejected) and
+// maxUsernameLength defaults to 30. Derive from a hash of the email so it
+// stays unique-per-run but well under the limit (4 + 16 = 20 chars), even
+// after specs append `_2`, `_b`, etc.
+const makeTestUsername = (email: string): string => {
+  const hash = crypto.createHash("sha256").update(email).digest("hex").slice(0, 16);
+  return `e2e_${hash}`;
+};
 
 export { makeTestEmail, makeTestUsername };


### PR DESCRIPTION
## Summary
Five related fixes that get the local \`auth-email/\` e2e suite to pass 4/4 against a real Resend dev key.

- **\`apps/web/src/lib/auth.ts\`** forwards \`RESEND_API_KEY\` + \`RESEND_FROM_EMAIL\` to \`createAuth()\`. Without the key, \`@repo/auth\` falls back to \`requireEmailVerification: false\` — a different code path than what \`auth-email/*\` asserts against.
- **\`onboarding@resend.dev\` as the \`fromEmail\` fallback** (in \`apps/web/src/lib/auth.ts\`, \`apps/api/src/lib/env.ts\`, \`apps/api/.env.example\`). \`acme.com\` isn't verified in Resend, so every send fails with \`validation_error\`. \`onboarding@resend.dev\` is Resend's universal test address — same pattern collabtime uses locally.
- **\`apps/web/src/middleware.ts\` → \`apps/web/src/proxy.ts\`**. Acme is on Next 16. \`middleware.ts\` runs in Edge Runtime; importing \`getAuth\` (which pulls in Prisma + \`node:crypto\`) crashes the bundle and \`/verify-email/success\` returns 404. \`proxy.ts\` is the Node-runtime equivalent — same logic, same matcher. Matches the easeia pattern.
- **\`auth-email/*.spec.ts\`** declare \`test.use({ storageState: { cookies: [], origins: [] } })\` so the chromium project's signed-in storageState doesn't bleed into the \`request\` fixture. Without it, the signup POST carries the setup user's session cookie and Better Auth rejects with 403. Same fix already in collabtime/frow/easeia.
- **\`tests/e2e/helpers/test-email.ts\`** — \`makeTestUsername\` was deriving from the email slug, producing 34+ chars and tripping Better Auth's default \`maxUsernameLength: 30\` → 400 on every signup. Switched to a 16-char sha256 prefix (\`e2e_<hash>\`, 20 chars), matching easeia.

## Test plan
- [x] Local e2e: \`playwright test tests/e2e/auth-email --project=chromium --no-deps --workers=1\` → 4/4 pass against acme-dev Resend key
- [x] Existing api env-default test updated to match new \`FROM_EMAIL\` default