### PR TITLE
feat(e2e): add canonical E2E workflow + standardize setup spec

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,19 +66,23 @@ jobs:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ steps.pw.outputs.version }}
       # CI runs the chromium project only (playwright.config.ts filters
-      # firefox/webkit out under CI). Installing all three browsers
-      # doubles wall-clock and risks transient CDN hangs on firefox/
-      # webkit downloads — pin the install to chromium.
-      - if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install chromium
-      # System deps come from apt; Ubuntu mirrors occasionally fail mid-sync
-      # ("File has unexpected size... Mirror sync in progress?"). Retry up
-      # to 3 times with apt-get update in between to ride out transient
-      # mirror flaps.
-      - name: Install Playwright system deps
+      # firefox/webkit out under CI). Use `--with-deps` so the browser
+      # download + apt system-deps install happen in one step, with a
+      # hard 10-min timeout so a stalled CDN extract doesn't sit idle
+      # for the full 45-min job budget. Invoke the binary directly via
+      # `node node_modules/.bin/playwright` — the pnpm-exec wrapper has
+      # been observed to hang silently after the chromium zip download
+      # on fresh caches.
+      - name: Install Playwright (chromium + system deps)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 10
+        run: node node_modules/.bin/playwright install --with-deps chromium
+      - name: Install Playwright system deps (cached browser)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 5
         run: |
           attempt=0
-          until pnpm exec playwright install-deps; do
+          until node node_modules/.bin/playwright install-deps chromium; do
             attempt=$((attempt + 1))
             if [ "$attempt" -ge 3 ]; then
               echo "playwright install-deps failed after $attempt attempts"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,41 +57,13 @@ jobs:
       - run: pnpm build --filter=web --filter=api --filter=landing
       - name: Seed E2E test user
         run: pnpm --filter web exec tsx scripts/ensure-e2e-user.ts
-      - name: Get Playwright version
-        id: pw
-        run: echo "version=$(pnpm exec playwright --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4
-        id: pw-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: pw-${{ runner.os }}-${{ steps.pw.outputs.version }}
-      # CI runs the chromium project only (playwright.config.ts filters
-      # firefox/webkit out under CI). Use `--with-deps` so the browser
-      # download + apt system-deps install happen in one step, with a
-      # hard 10-min timeout so a stalled CDN extract doesn't sit idle
-      # for the full 45-min job budget. Invoke the binary directly via
-      # `node node_modules/.bin/playwright` — the pnpm-exec wrapper has
-      # been observed to hang silently after the chromium zip download
-      # on fresh caches.
-      - name: Install Playwright (chromium + system deps)
-        if: steps.pw-cache.outputs.cache-hit != 'true'
-        timeout-minutes: 10
-        run: node node_modules/.bin/playwright install --with-deps chromium
-      - name: Install Playwright system deps (cached browser)
-        if: steps.pw-cache.outputs.cache-hit == 'true'
-        timeout-minutes: 5
-        run: |
-          attempt=0
-          until node node_modules/.bin/playwright install-deps chromium; do
-            attempt=$((attempt + 1))
-            if [ "$attempt" -ge 3 ]; then
-              echo "playwright install-deps failed after $attempt attempts"
-              exit 1
-            fi
-            echo "apt fetch failed (attempt $attempt); retrying in 30s..."
-            sleep 30
-            sudo apt-get update || true
-          done
+      # Canonical Playwright CI pattern (playwright.dev/docs/ci): browser
+      # download + apt system deps in one step. Caching is explicitly
+      # *not* recommended by the docs — restore time is comparable to a
+      # fresh download. The chromium pin matches playwright.config.ts
+      # which filters firefox/webkit out under CI.
+      - name: Install Playwright browsers and system deps
+        run: pnpm exec playwright install --with-deps chromium
       - run: pnpm test:e2e
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,8 +65,12 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ steps.pw.outputs.version }}
+      # CI runs the chromium project only (playwright.config.ts filters
+      # firefox/webkit out under CI). Installing all three browsers
+      # doubles wall-clock and risks transient CDN hangs on firefox/
+      # webkit downloads — pin the install to chromium.
       - if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install
+        run: pnpm exec playwright install chromium
       # System deps come from apt; Ubuntu mirrors occasionally fail mid-sync
       # ("File has unexpected size... Mirror sync in progress?"). Retry up
       # to 3 times with apt-get update in between to ride out transient

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,93 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      CI: true
+      DATABASE_URL: postgresql://test:test@localhost:5432/test
+      BETTER_AUTH_SECRET: test-secret-minimum-32-characters-long-for-e2e
+      # Use 127.0.0.1 (not localhost) to match playwright.config.ts baseURL.
+      # Mismatched hosts split cookie scope: sign-in sets cookies on
+      # 127.0.0.1 but cross-origin fetches to localhost don't send them,
+      # producing 401s on every authed API request from browser tests.
+      NEXT_PUBLIC_API_URL: http://127.0.0.1:4000
+      WEB_APP_URL: http://127.0.0.1:3000
+      # Gates the tests/e2e/auth-email/* suite. When unset (forks,
+      # contributors without secret access), those specs `test.skip()`
+      # themselves and the rest of the suite still runs. When set, the
+      # auth server flips on requireEmailVerification — the seed script
+      # bypasses that for the canonical e2e-test user by writing
+      # emailVerified: true directly to Prisma.
+      RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+    services:
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U test -d test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm db:generate
+      - run: pnpm db:push
+      - run: pnpm build --filter=web --filter=api --filter=landing
+      - name: Seed E2E test user
+        run: pnpm --filter web exec tsx scripts/ensure-e2e-user.ts
+      - name: Get Playwright version
+        id: pw
+        run: echo "version=$(pnpm exec playwright --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
+        id: pw-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ steps.pw.outputs.version }}
+      - if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install
+      # System deps come from apt; Ubuntu mirrors occasionally fail mid-sync
+      # ("File has unexpected size... Mirror sync in progress?"). Retry up
+      # to 3 times with apt-get update in between to ride out transient
+      # mirror flaps.
+      - name: Install Playwright system deps
+        run: |
+          attempt=0
+          until pnpm exec playwright install-deps; do
+            attempt=$((attempt + 1))
+            if [ "$attempt" -ge 3 ]; then
+              echo "playwright install-deps failed after $attempt attempts"
+              exit 1
+            fi
+            echo "apt fetch failed (attempt $attempt); retrying in 30s..."
+            sleep 30
+            sudo apt-get update || true
+          done
+      - run: pnpm test:e2e
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/apps/api/tsdown.config.ts
+++ b/apps/api/tsdown.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
     // Workspace packages export .ts source — Node can't import those at runtime,
     // so tsdown must bundle them into the output instead of leaving them as external imports.
     alwaysBundle: ["@repo/auth", "@repo/auth/server", "@repo/db", "@repo/transactional"],
+    // pino-pretty spawns its own worker_threads worker at `./lib/worker.js`
+    // relative to the bundle — when pino is bundled, the worker file is
+    // missing and the runtime errors with
+    // `Cannot find module 'apps/api/dist/lib/worker.js'`. Keep pino external
+    // so its worker files stay accessible via node_modules.
+    neverBundle: ["pino", "pino-pretty"],
   },
   entry: ["src/index.ts"],
   format: ["esm"],

--- a/apps/web/scripts/ensure-e2e-user.ts
+++ b/apps/web/scripts/ensure-e2e-user.ts
@@ -1,0 +1,77 @@
+/**
+ * Idempotent LOCAL-only seed for the E2E test user. Invoked by Playwright's
+ * setup spec (and CI) before any other spec runs, so the e2e suite never
+ * depends on the local DB being in any particular state — nuke it,
+ * re-sync, skip a step, the user will be (re)created on next run.
+ *
+ * NEVER point this at prod: it creates a known-password user. The
+ * hard-coded `postgresql://...@localhost:...` check on DATABASE_URL is
+ * the guard.
+ *
+ * Invoke:
+ *   pnpm --filter web exec tsx scripts/ensure-e2e-user.ts
+ */
+
+import { prisma } from "@repo/db";
+
+import { getAuth } from "@/lib/auth";
+
+const EMAIL = "e2e-test@acme.localhost";
+const NAME = "E2E Test User";
+const PASSWORD = "TestPassword123!";
+const SLUG = "e2e-test-user";
+
+const main = async () => {
+  const dbUrl = process.env.DATABASE_URL ?? "";
+  const isLocal =
+    (dbUrl.startsWith("postgres://") || dbUrl.startsWith("postgresql://")) &&
+    (dbUrl.includes("localhost") || dbUrl.includes("127.0.0.1"));
+  if (!isLocal) {
+    throw new Error(
+      `Refusing to run ensure-e2e-user.ts against non-local DATABASE_URL (${dbUrl}).`,
+    );
+  }
+
+  const ctx = await getAuth().$context;
+  const hashed = await ctx.password.hash(PASSWORD);
+
+  // Upsert returns the actual user row — existing users keep their
+  // original id, not SLUG — so use the returned `id` for the account FK.
+  const user = await prisma.user.upsert({
+    create: {
+      email: EMAIL,
+      // Better Auth refuses sign-in for unverified accounts when
+      // requireEmailVerification is on, so the seeded user has to land
+      // already verified. Safe because this script is local-only
+      // (DATABASE_URL guard above).
+      emailVerified: true,
+      id: SLUG,
+      name: NAME,
+    },
+    update: {
+      // Re-runs keep existing rows intact. Refresh the verification flag
+      // so accounts seeded before this fix get backfilled instead of
+      // staying stuck on EMAIL_NOT_VERIFIED.
+      emailVerified: true,
+      name: NAME,
+    },
+    where: { email: EMAIL },
+  });
+
+  await prisma.account.upsert({
+    create: {
+      accountId: user.id,
+      password: hashed,
+      providerId: "credential",
+      userId: user.id,
+    },
+    update: { password: hashed },
+    where: { providerId_accountId: { accountId: user.id, providerId: "credential" } },
+  });
+
+  // eslint-disable-next-line no-console -- CI step output: surface the seed result.
+  console.log(`✓ e2e user ${EMAIL} ready; password: ${PASSWORD}`);
+  await prisma.$disconnect();
+};
+
+await main();

--- a/apps/web/src/app/(auth)/verify-email/pending-screen.tsx
+++ b/apps/web/src/app/(auth)/verify-email/pending-screen.tsx
@@ -161,8 +161,8 @@ const PendingScreen = ({ token }: Props) => {
         <CardTitle className="text-xl">Check your inbox</CardTitle>
         <CardDescription>
           We sent a verification link to{" "}
-          <span className="font-medium text-foreground">{credentials.email}</span>. Click it to finish
-          signing in — this page will continue automatically.
+          <span className="font-medium text-foreground">{credentials.email}</span>. Click it to
+          finish signing in — this page will continue automatically.
         </CardDescription>
       </CardHeader>
       <CardContent className="text-center text-sm text-muted-foreground">

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -25,6 +25,7 @@ export const proxy = async (request: NextRequest) => {
     .catch((error) => {
       // Auth service failure (DB down, misconfiguration, etc.) — log so outages
       // are observable, then treat as unauthenticated to keep the pipeline moving.
+      // eslint-disable-next-line no-console -- proxy runs server-side; this is the runtime observability channel.
       console.error("[proxy] getSession failed — treating as unauthenticated", { error, pathname });
       return null;
     });

--- a/docs/superpowers/plans/2026-05-26-deslop-standardization.md
+++ b/docs/superpowers/plans/2026-05-26-deslop-standardization.md
@@ -15,10 +15,12 @@
 ## File Map
 
 ### Preflight PR
+
 - Modify: `apps/api/src/middleware/auth.test.ts` (already unstaged)
 - Modify: `apps/api/src/middleware/error-handler.test.ts` (already unstaged)
 
 ### PR A — Structural
+
 - Delete: `apps/api/src/services/user.service.ts`
 - Delete: `apps/api/src/services/user.service.test.ts`
 - Delete: `apps/api/src/services/` (empty after the two deletions)
@@ -32,6 +34,7 @@
 - Modify: `packages/auth/package.json`
 
 ### PR B — Patterns + CONVENTIONS.md
+
 - Modify: `apps/api/src/routes/v1/users.ts` (deleteMe response → 204)
 - Modify: `apps/web/src/lib/auth-helpers.ts` (drop try/catch)
 - Move: `packages/transactional/src/utils/send-email.ts` → `packages/transactional/src/lib/send-email.ts`
@@ -41,6 +44,7 @@
 - Modify: `CLAUDE.md` (add link to CONVENTIONS.md)
 
 ### PR C — Hygiene
+
 - Create: `apps/api/src/middleware/test-helpers.ts`
 - Modify: `apps/api/src/middleware/auth.test.ts`
 - Modify: `apps/api/src/middleware/error-handler.test.ts`
@@ -58,6 +62,7 @@ The current working tree has two unstaged fixes (`auth.test.ts`, `error-handler.
 ### Task P1: Land the middleware test fixes
 
 **Files:**
+
 - Modify: `apps/api/src/middleware/auth.test.ts` (already in working tree)
 - Modify: `apps/api/src/middleware/error-handler.test.ts` (already in working tree)
 
@@ -65,10 +70,12 @@ The current working tree has two unstaged fixes (`auth.test.ts`, `error-handler.
 
 Run: `git diff --stat apps/api/src/middleware/`
 Expected:
+
 ```
  apps/api/src/middleware/auth.test.ts          |  4 ++++
  apps/api/src/middleware/error-handler.test.ts | 11 ++++-------
 ```
+
 If anything else is touched, stop and investigate.
 
 - [ ] **Step 2: Run api tests to confirm they pass with the unstaged fix in place**
@@ -141,6 +148,7 @@ Expected: All checks pass.
 ### Task A2: Write the failing test for `findUserById` in the new location
 
 **Files:**
+
 - Create: `apps/api/src/lib/users.test.ts`
 
 - [ ] **Step 1: Create the new test file with the same coverage as the old service test, against the new function-based API**
@@ -352,6 +360,7 @@ Expected: FAIL with "Failed to resolve import './users'".
 ### Task A3: Implement `apps/api/src/lib/users.ts`
 
 **Files:**
+
 - Create: `apps/api/src/lib/users.ts`
 
 - [ ] **Step 1: Write the new module with `userSelect` constant + four async functions**
@@ -476,15 +485,19 @@ Expected: PASS (`Tests  12 passed (12)`).
 ### Task A4: Update the route call sites in `apps/api/src/routes/v1/users.ts`
 
 **Files:**
+
 - Modify: `apps/api/src/routes/v1/users.ts`
 
 - [ ] **Step 1: Replace the import line**
 
 In `apps/api/src/routes/v1/users.ts`, replace:
+
 ```ts
 import { userService } from "@/services/user.service";
 ```
+
 with:
+
 ```ts
 import { deleteUser, findUserById, updateUser } from "@/lib/users";
 ```
@@ -492,22 +505,25 @@ import { deleteUser, findUserById, updateUser } from "@/lib/users";
 - [ ] **Step 2: Update the `ServiceUser` type alias**
 
 Replace:
+
 ```ts
 type ServiceUser = Awaited<ReturnType<typeof userService.findById>>;
 ```
+
 with:
+
 ```ts
 type ServiceUser = Awaited<ReturnType<typeof findUserById>>;
 ```
 
 - [ ] **Step 3: Update the four call sites**
 
-| Line (current) | Old | New |
-|---|---|---|
-| 73 | `await userService.findById(user.id)` | `await findUserById(user.id)` |
-| 109 | `await userService.update(user.id, data)` | `await updateUser(user.id, data)` |
-| 134 | `await userService.delete(user.id)` | `await deleteUser(user.id)` |
-| 173 | `await userService.findById(user.id)` | `await findUserById(user.id)` |
+| Line (current) | Old                                       | New                               |
+| -------------- | ----------------------------------------- | --------------------------------- |
+| 73             | `await userService.findById(user.id)`     | `await findUserById(user.id)`     |
+| 109            | `await userService.update(user.id, data)` | `await updateUser(user.id, data)` |
+| 134            | `await userService.delete(user.id)`       | `await deleteUser(user.id)`       |
+| 173            | `await userService.findById(user.id)`     | `await findUserById(user.id)`     |
 
 - [ ] **Step 4: Run typecheck + tests**
 
@@ -517,6 +533,7 @@ Expected: typecheck clean; all api tests pass (both `services/user.service.test.
 ### Task A5: Delete the old service files
 
 **Files:**
+
 - Delete: `apps/api/src/services/user.service.ts`
 - Delete: `apps/api/src/services/user.service.test.ts`
 - Delete: `apps/api/src/services/` (directory, if empty)
@@ -542,6 +559,7 @@ Expected: typecheck clean; all api tests pass (lower total than before — `user
 ### Task A6: Inline the `createResendClient` wrapper
 
 **Files:**
+
 - Delete: `packages/transactional/src/client.ts`
 - Modify: `packages/transactional/src/utils/send-email.ts`
 - Modify: `packages/transactional/src/index.ts`
@@ -549,11 +567,14 @@ Expected: typecheck clean; all api tests pass (lower total than before — `user
 - [ ] **Step 1: Remove the re-export from the package barrel**
 
 In `packages/transactional/src/index.ts`, delete lines 1-2:
+
 ```ts
 // Client
 export { createResendClient } from "./client";
 ```
+
 The file becomes:
+
 ```ts
 // Components
 export { AcmeLogo } from "./components/acme-logo";
@@ -579,28 +600,37 @@ export { emailTheme, tailwindConfig } from "./styles/theme";
 In `packages/transactional/src/utils/send-email.ts`:
 
 1. Replace the import block at the top:
+
 ```ts
 import { createResendClient } from "../client";
 ```
+
 with:
+
 ```ts
 import { Resend } from "resend";
 ```
 
 2. Replace line 51 (inside `sendEmail`):
+
 ```ts
 const resend = createResendClient(apiKey);
 ```
+
 with:
+
 ```ts
 const resend = new Resend(apiKey);
 ```
 
 3. Replace line 104 (inside `sendBatchEmails`):
+
 ```ts
 const resend = createResendClient(apiKey);
 ```
+
 with:
+
 ```ts
 const resend = new Resend(apiKey);
 ```
@@ -626,6 +656,7 @@ Expected: zero matches.
 ### Task A7: Fix the `lucide-react` phantom dep
 
 **Files:**
+
 - Modify: `packages/ui/package.json`
 
 - [ ] **Step 1: Confirm `lucide-react` is unused inside `packages/ui/src`**
@@ -646,11 +677,13 @@ pnpm build --filter @repo/ui
 pnpm build --filter web
 pnpm build --filter landing
 ```
+
 Expected: all clean.
 
 ### Task A8: Remove unused `@tanstack/react-form` devDep from `packages/auth`
 
 **Files:**
+
 - Modify: `packages/auth/package.json`
 
 - [ ] **Step 1: Confirm it is not imported anywhere in `packages/auth/src`**
@@ -669,6 +702,7 @@ pnpm install
 pnpm --filter @repo/auth typecheck
 pnpm --filter @repo/auth test
 ```
+
 Expected: both clean.
 
 ### Task A9: Final verification + commit + push + PR
@@ -683,6 +717,7 @@ pnpm test
 pnpm fallow:dead
 pnpm build
 ```
+
 Expected: every command green. `pnpm fallow:dead` should now report zero unused deps.
 
 - [ ] **Step 2: Commit**
@@ -748,6 +783,7 @@ Expected: All checks pass.
 ### Task B2: Change `DELETE /me` to 204 No Content
 
 **Files:**
+
 - Modify: `apps/api/src/routes/v1/users.ts` (the `deleteMeRoute` schema + handler)
 
 - [ ] **Step 1: Update the route schema**
@@ -755,6 +791,7 @@ Expected: All checks pass.
 In `apps/api/src/routes/v1/users.ts`, replace the `responses` block of `deleteMeRoute`:
 
 Old (lines 118-127 in the current file):
+
 ```ts
   responses: {
     200: {
@@ -769,6 +806,7 @@ Old (lines 118-127 in the current file):
 ```
 
 New:
+
 ```ts
   responses: {
     204: {
@@ -786,6 +824,7 @@ New:
 Replace the handler body:
 
 Old:
+
 ```ts
 v1UserRoutes.openapi(deleteMeRoute, async (c) => {
   const user = c.get("user");
@@ -795,6 +834,7 @@ v1UserRoutes.openapi(deleteMeRoute, async (c) => {
 ```
 
 New — only the return statement changes; leave the existing delete call as-is. If PR A has already merged, the call reads `await deleteUser(user.id)`; if not, it reads `await userService.delete(user.id)`. PR B does not touch that line:
+
 ```ts
 v1UserRoutes.openapi(deleteMeRoute, async (c) => {
   const user = c.get("user");
@@ -809,11 +849,13 @@ v1UserRoutes.openapi(deleteMeRoute, async (c) => {
 pnpm --filter api typecheck
 pnpm --filter api test
 ```
+
 Expected: both clean.
 
 ### Task B3: Stop swallowing errors in `apps/web/src/lib/auth-helpers.ts`
 
 **Files:**
+
 - Modify: `apps/web/src/lib/auth-helpers.ts`
 
 - [ ] **Step 1: Replace the file**
@@ -840,6 +882,7 @@ The `try/catch` and `console.error` are gone. Better Auth returns `null` for "no
 pnpm --filter web typecheck
 pnpm --filter web test
 ```
+
 Expected: both clean.
 
 - [ ] **Step 3: Manual smoke (optional)**
@@ -849,6 +892,7 @@ Start `pnpm dev --filter web`, navigate to a page that calls `getSession`, confi
 ### Task B4: Rename `packages/transactional/src/utils/` → `lib/`
 
 **Files:**
+
 - Move: `packages/transactional/src/utils/send-email.ts` → `packages/transactional/src/lib/send-email.ts`
 - Move: `packages/transactional/src/utils/senders.ts` → `packages/transactional/src/lib/senders.ts`
 - Modify: `packages/transactional/src/index.ts`
@@ -865,6 +909,7 @@ rmdir packages/transactional/src/utils
 - [ ] **Step 2: Update the barrel exports in `packages/transactional/src/index.ts`**
 
 Change:
+
 ```ts
 export { sendEmail, sendBatchEmails, previewEmail } from "./utils/send-email";
 export {
@@ -874,7 +919,9 @@ export {
   sendSignUpAttemptEmail,
 } from "./utils/senders";
 ```
+
 to:
+
 ```ts
 export { sendEmail, sendBatchEmails, previewEmail } from "./lib/send-email";
 export {
@@ -888,9 +935,11 @@ export {
 - [ ] **Step 3: Update any cross-file imports inside `packages/transactional/src/lib/`**
 
 `senders.ts` may import from `./send-email`; since both files moved together, relative imports stay the same. Confirm:
+
 ```bash
 git grep -n "from \"\\.\\./utils" packages/transactional
 ```
+
 Expected: zero matches.
 
 - [ ] **Step 4: Verify**
@@ -900,11 +949,13 @@ pnpm --filter @repo/transactional typecheck
 pnpm --filter @repo/transactional build
 pnpm --filter @repo/transactional test
 ```
+
 Expected: all clean.
 
 ### Task B5: Write `docs/CONVENTIONS.md`
 
 **Files:**
+
 - Create: `docs/CONVENTIONS.md`
 
 - [ ] **Step 1: Create the file**
@@ -926,7 +977,7 @@ This document records the defaults used across the acme monorepo. New code shoul
 
 - Never swallow into `null`, `{}`, or empty arrays. A returned-null on the success path is fine when it means "no row"; a returned-null in a catch block is silent failure.
 - In api middleware and route handlers: throw `HTTPException` (for HTTP-specific errors) or `AppError` (for domain errors). The central handler renders the response and logs via `c.var.logger`.
-- In Next.js RSC helpers (e.g. `apps/web/src/lib/auth-helpers.ts`): do not wrap in try/catch unless you are handling a *specific* expected error. Let unknown failures propagate — Next.js renders `error.tsx` and Vercel captures the stack with full context.
+- In Next.js RSC helpers (e.g. `apps/web/src/lib/auth-helpers.ts`): do not wrap in try/catch unless you are handling a _specific_ expected error. Let unknown failures propagate — Next.js renders `error.tsx` and Vercel captures the stack with full context.
 - `console.error` is not a logger. The api uses `c.var.logger` (from `@hono/structured-logger`); the web app relies on Next.js + Vercel error capture for thrown exceptions.
 
 ## File organization
@@ -974,6 +1025,7 @@ This document records the defaults used across the acme monorepo. New code shoul
 ### Task B6: Link `CONVENTIONS.md` from `CLAUDE.md`
 
 **Files:**
+
 - Modify: `CLAUDE.md`
 
 - [ ] **Step 1: Add a one-line pointer near the top of CLAUDE.md, right after the `Commands` section heading or in the existing intro**
@@ -981,7 +1033,6 @@ This document records the defaults used across the acme monorepo. New code shoul
 In `CLAUDE.md`, find the line `This file provides guidance to AI coding agents when working with code in this repository.` and add immediately after it:
 
 ```markdown
-
 Project conventions and defaults are documented in [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md).
 ```
 
@@ -996,6 +1047,7 @@ pnpm typecheck
 pnpm test
 pnpm build
 ```
+
 Expected: every command green.
 
 - [ ] **Step 2: Commit**
@@ -1061,6 +1113,7 @@ Expected: All checks pass.
 ### Task C2: Create the shared test-context helper
 
 **Files:**
+
 - Create: `apps/api/src/middleware/test-helpers.ts`
 
 - [ ] **Step 1: Write the helper**
@@ -1134,6 +1187,7 @@ Expected: clean.
 ### Task C3: Refactor `auth.test.ts` to use the shared helper
 
 **Files:**
+
 - Modify: `apps/api/src/middleware/auth.test.ts`
 
 - [ ] **Step 1: Replace the file contents**
@@ -1304,6 +1358,7 @@ Expected: 10 tests passing, no `as unknown as` in the file.
 ### Task C4: Refactor `error-handler.test.ts` to use the shared helper
 
 **Files:**
+
 - Modify: `apps/api/src/middleware/error-handler.test.ts`
 
 - [ ] **Step 1: Replace the file contents**
@@ -1495,6 +1550,7 @@ Expected: all passing, no `as unknown as` in the file.
 ### Task C5: Refactor `security.test.ts` to use the shared helper
 
 **Files:**
+
 - Modify: `apps/api/src/middleware/security.test.ts`
 
 - [ ] **Step 1: Replace the file contents**
@@ -1577,6 +1633,7 @@ Expected: zero matches.
 ### Task C6: Trim cookie-Secure comment in `packages/auth/src/server.ts`
 
 **Files:**
+
 - Modify: `packages/auth/src/server.ts:55-72`
 
 - [ ] **Step 1: Replace the 12-line comment block**
@@ -1584,6 +1641,7 @@ Expected: zero matches.
 In `packages/auth/src/server.ts`, replace lines 59-71 (the multi-paragraph block above `useSecureCookies:`) with a single-line comment:
 
 Old (lines 59-71):
+
 ```ts
       // Force the `Secure` cookie flag when WEB_APP_URL is HTTPS. The
       // dynamic-baseURL `protocol: "auto"` setting documents this as
@@ -1602,6 +1660,7 @@ Old (lines 59-71):
 ```
 
 New:
+
 ```ts
       // Reverse proxy (portless / Vercel) hides the HTTPS scheme from Better Auth's auto-detection;
       // gate on WEB_APP_URL instead — unset in CI keeps tests on plain HTTP.
@@ -1614,16 +1673,19 @@ New:
 pnpm --filter @repo/auth typecheck
 pnpm --filter @repo/auth test
 ```
+
 Expected: both clean.
 
 ### Task C7: Trim the env-throw comment in `apps/api/src/lib/env.ts`
 
 **Files:**
+
 - Modify: `apps/api/src/lib/env.ts:18-23`
 
 - [ ] **Step 1: Drop the defensive justification**
 
 Replace:
+
 ```ts
 if (!parsedEnv.success) {
   // Throwing at module load aborts the process with a stack trace; preferable to
@@ -1633,7 +1695,9 @@ if (!parsedEnv.success) {
   );
 }
 ```
+
 with:
+
 ```ts
 if (!parsedEnv.success) {
   throw new Error(
@@ -1648,11 +1712,13 @@ if (!parsedEnv.success) {
 pnpm --filter api typecheck
 pnpm --filter api test
 ```
+
 Expected: both clean.
 
 ### Task C8: Trim the optional-auth-middleware comment
 
 **Files:**
+
 - Modify: `apps/api/src/middleware/auth.ts:80-87`
 
 - [ ] **Step 1: Compress the parenthetical**
@@ -1660,6 +1726,7 @@ Expected: both clean.
 In `apps/api/src/middleware/auth.ts`, replace lines 81-83:
 
 Old:
+
 ```ts
   } catch (error) {
     // Unexpected failures (DB down, malformed token, rate limit exception) must
@@ -1669,6 +1736,7 @@ Old:
 ```
 
 New:
+
 ```ts
   } catch (error) {
     // Log unexpected failures; a missing user context is otherwise indistinguishable from an outage.
@@ -1681,6 +1749,7 @@ New:
 pnpm --filter api typecheck
 pnpm --filter api test
 ```
+
 Expected: both clean.
 
 ### Task C9: Quick sweep for other AI-slop comments
@@ -1688,6 +1757,7 @@ Expected: both clean.
 This step is bounded — look at the files below; if a comment is WHAT-shaped, redundant, or history-shaped, trim it. Do not rewrite WHY-comments that are pulling their weight. Maximum ~10 minutes; this is not a rabbit hole.
 
 **Files to scan (one at a time):**
+
 - `apps/api/src/index.ts`
 - `apps/api/src/lib/auth.ts`
 - `apps/api/src/lib/openapi.ts`
@@ -1712,6 +1782,7 @@ This step is bounded — look at the files below; if a comment is WHAT-shaped, r
 pnpm lint
 pnpm format:check
 ```
+
 Expected: clean.
 
 ### Task C10: Final verification + commit + push + PR
@@ -1725,6 +1796,7 @@ pnpm typecheck
 pnpm test
 pnpm build
 ```
+
 Expected: every command green; api test count unchanged at 56 (the structural test moves are PR A, not PR C).
 
 - [ ] **Step 2: Confirm zero `as unknown as` casts in middleware tests**

--- a/docs/superpowers/specs/2026-05-26-deslop-standardization-design.md
+++ b/docs/superpowers/specs/2026-05-26-deslop-standardization-design.md
@@ -25,11 +25,11 @@ Reduce code-review friction and prevent future "which way do we do this?" debate
 
 Three independent PRs, designed to minimize file-level overlap so they can land in any order:
 
-| PR | Theme | Risk |
-|---|---|---|
-| **A** | Structural + dead deps + api file rename | Medium |
+| PR    | Theme                                                                | Risk   |
+| ----- | -------------------------------------------------------------------- | ------ |
+| **A** | Structural + dead deps + api file rename                             | Medium |
 | **B** | Pattern standardization + transactional file rename + CONVENTIONS.md | Higher |
-| **C** | Comment + cast hygiene | Low |
+| **C** | Comment + cast hygiene                                               | Low    |
 
 The api `services/` → `lib/` rename is folded into PR A (it owns `user.service.ts` already) so PR B doesn't touch the same file. PR B owns the transactional `utils/` → `lib/` rename and the new conventions doc.
 
@@ -159,17 +159,18 @@ Short reference doc capturing the defaults. Final content lives in the PR; outli
 
 ### C1. Comment trim pass
 
-| File | Lines (current) | Action |
-|---|---|---|
-| `packages/auth/src/server.ts` | 59-71 | Compress 12-line cookie-Secure block → one sentence on the reverse-proxy edge case |
-| `apps/api/src/lib/env.ts` | 19-22 | Drop the "throwing vs `process.exit`" defense; code is self-explanatory |
-| `apps/api/src/middleware/auth.ts` | 81-83 | Keep the "must not be silent" WHY; drop the parenthetical examples list |
+| File                              | Lines (current) | Action                                                                             |
+| --------------------------------- | --------------- | ---------------------------------------------------------------------------------- |
+| `packages/auth/src/server.ts`     | 59-71           | Compress 12-line cookie-Secure block → one sentence on the reverse-proxy edge case |
+| `apps/api/src/lib/env.ts`         | 19-22           | Drop the "throwing vs `process.exit`" defense; code is self-explanatory            |
+| `apps/api/src/middleware/auth.ts` | 81-83           | Keep the "must not be silent" WHY; drop the parenthetical examples list            |
 
 Then a quick sweep of the rest of the codebase for the same shape: verbose JSDoc explaining trivial behavior, history references, redundant `// returns: ...` lines, "added for X" tags.
 
 ### C2. Typed Context mock helper
 
 - New file: `apps/api/src/middleware/test-helpers.ts`
+
   ```ts
   type MockContextOptions = {
     headers?: Record<string, string>;
@@ -182,7 +183,9 @@ Then a quick sweep of the rest of the codebase for the same shape: verbose JSDoc
 
     return {
       get: vi.fn((key: string) => variables.get(key)),
-      set: vi.fn((key: string, value: unknown) => { variables.set(key, value); }),
+      set: vi.fn((key: string, value: unknown) => {
+        variables.set(key, value);
+      }),
       var: { logger },
       req: {
         header: vi.fn((name: string) => opts.headers?.[name]),
@@ -194,6 +197,7 @@ Then a quick sweep of the rest of the codebase for the same shape: verbose JSDoc
     } satisfies Partial<Context>;
   };
   ```
+
 - Each of `auth.test.ts`, `error-handler.test.ts`, `security.test.ts` drops its local `createMockContext` and imports from the helper.
 - The `as unknown as Context` casts go away (`satisfies Partial<Context>` is the proper escape hatch).
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "^1.60.0",
     "@repo/db": "workspace:*",
     "fallow": "^2.69.0",
     "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@playwright/test':
-        specifier: ^1.59.1
-        version: 1.59.1
+        specifier: ^1.60.0
+        version: 1.60.0
       '@repo/db':
         specifier: workspace:*
         version: link:packages/db
@@ -110,13 +110,13 @@ importers:
         version: link:../../packages/ui
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.34(typescript@6.0.3))
+        version: 2.0.1(next@16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.34(typescript@6.0.3))
       lucide-react:
         specifier: ^1.14.0
         version: 1.14.0(react@19.2.6)
       next:
         specifier: ^16.2.6
-        version: 16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -174,13 +174,13 @@ importers:
         version: 1.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       better-auth:
         specifier: ^1.6.10
-        version: 1.6.10(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(mysql2@3.15.3)(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.20.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5)(vue@3.5.34(typescript@6.0.3))
+        version: 1.6.10(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(mysql2@3.15.3)(next@16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.20.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5)(vue@3.5.34(typescript@6.0.3))
       lucide-react:
         specifier: ^1.14.0
         version: 1.14.0(react@19.2.6)
       next:
         specifier: ^16.2.6
-        version: 16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -235,7 +235,7 @@ importers:
         version: link:../transactional
       better-auth:
         specifier: ^1.6.10
-        version: 1.6.10(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(mysql2@3.15.3)(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.20.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5)(vue@3.5.34(typescript@6.0.3))
+        version: 1.6.10(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(mysql2@3.15.3)(next@16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.20.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5)(vue@3.5.34(typescript@6.0.3))
     devDependencies:
       '@repo/config-vitest':
         specifier: workspace:*
@@ -334,7 +334,7 @@ importers:
     devDependencies:
       '@react-email/ui':
         specifier: ^6.1.1
-        version: 6.1.1(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.1.1(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@repo/config-vitest':
         specifier: workspace:*
         version: link:../config-vitest
@@ -454,6 +454,10 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.29.3':
     resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
     engines: {node: '>=6.9.0'}
@@ -532,6 +536,10 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@8.0.0-rc.3':
     resolution: {integrity: sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -600,6 +608,10 @@ packages:
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
@@ -1948,8 +1960,8 @@ packages:
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
-  '@playwright/test@1.59.1':
-    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2619,6 +2631,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
@@ -3050,8 +3065,8 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -4205,6 +4220,10 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
   jsdom@29.1.1:
     resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
@@ -4969,13 +4988,13 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4992,6 +5011,10 @@ packages:
 
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -5587,6 +5610,10 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
@@ -6100,6 +6127,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.29.3': {}
 
   '@babel/core@7.29.0':
@@ -6217,6 +6250,8 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-identifier@7.29.7': {}
+
   '@babel/helper-validator-identifier@8.0.0-rc.3': {}
 
   '@babel/helper-validator-identifier@8.0.0-rc.4': {}
@@ -6285,6 +6320,8 @@ snapshots:
       - supports-color
 
   '@babel/runtime@7.29.2': {}
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -6668,7 +6705,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -7200,9 +7237,9 @@ snapshots:
 
   '@pinojs/redact@0.4.0': {}
 
-  '@playwright/test@1.59.1':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.59.1
+      playwright: 1.60.0
 
   '@prisma/adapter-pg@7.8.0':
     dependencies:
@@ -7370,10 +7407,10 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@react-email/ui@6.1.1(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@react-email/ui@6.1.1(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       esbuild: 0.28.0
-      next: 16.2.3(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.3(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@babel/core'
       - '@opentelemetry/api'
@@ -7769,8 +7806,8 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.29.2
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -7846,6 +7883,8 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -7954,9 +7993,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vercel/analytics@2.0.1(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.34(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(next@16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.34(typescript@6.0.3))':
     optionalDependencies:
-      next: 16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       vue: 3.5.34(typescript@6.0.3)
 
@@ -8210,7 +8249,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.27: {}
 
-  better-auth@1.6.10(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(mysql2@3.15.3)(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.20.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5)(vue@3.5.34(typescript@6.0.3)):
+  better-auth@1.6.10(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(mysql2@3.15.3)(next@16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.20.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5)(vue@3.5.34(typescript@6.0.3)):
     dependencies:
       '@better-auth/core': 1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
@@ -8232,7 +8271,7 @@ snapshots:
     optionalDependencies:
       '@prisma/client': 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3)
       mysql2: 3.15.3
-      next: 16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       pg: 8.20.0
       prisma: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       react: 19.2.6
@@ -8274,7 +8313,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.15:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -8791,7 +8830,7 @@ snapshots:
       '@humanfs/node': 0.16.8
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -9492,6 +9531,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+
   jsdom@29.1.1(@noble/hashes@2.2.0):
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
@@ -10047,7 +10090,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.15
 
   minimist@1.2.8: {}
 
@@ -10112,7 +10155,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next@16.2.3(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.2.3(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
@@ -10131,13 +10174,13 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.3
       '@next/swc-win32-arm64-msvc': 16.2.3
       '@next/swc-win32-x64-msvc': 16.2.3
-      '@playwright/test': 1.59.1
+      '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -10156,7 +10199,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.6
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
-      '@playwright/test': 1.59.1
+      '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -10479,11 +10522,11 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.59.1:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -10501,6 +10544,12 @@ snapshots:
       source-map-js: 1.2.1
 
   postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -11254,6 +11303,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinypool@2.1.0: {}
 
   tinyrainbow@3.1.0: {}
@@ -11467,9 +11521,9 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.14
+      postcss: 8.5.15
       rolldown: 1.0.0-rc.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.6.2
       esbuild: 0.27.7

--- a/tests/e2e/auth/logout.spec.ts
+++ b/tests/e2e/auth/logout.spec.ts
@@ -19,10 +19,19 @@ const createIsolatedUser = async (request: APIRequestContext): Promise<string> =
   return email;
 };
 
+// With RESEND_API_KEY set, requireEmailVerification flips on and a
+// fresh-signup-then-sign-in flow can't land at /dashboard — the user
+// stays on the verify-pending screen. The auth-email/* suite covers
+// the Resend path; these UI logout assertions belong to the
+// no-Resend local-dev path.
+const skipUnderResend = !!process.env.RESEND_API_KEY;
+
 test.describe("Logout", () => {
   test.use({ storageState: { cookies: [], origins: [] } });
 
   test("signs out and redirects to login", async ({ dashboardPage, loginPage, page, request }) => {
+    test.skip(skipUnderResend, "Resend-enabled flow blocks fresh-signup → sign-in");
+
     const email = await createIsolatedUser(request);
     await loginPage.goto();
     await loginPage.login(email, PASSWORD);
@@ -41,6 +50,8 @@ test.describe("Logout", () => {
     page,
     request,
   }) => {
+    test.skip(skipUnderResend, "Resend-enabled flow blocks fresh-signup → sign-in");
+
     const email = await createIsolatedUser(request);
     await loginPage.goto();
     await loginPage.login(email, PASSWORD);

--- a/tests/e2e/auth/recovery.spec.ts
+++ b/tests/e2e/auth/recovery.spec.ts
@@ -18,7 +18,8 @@ test.describe("Password Recovery", () => {
     await recoverPage.goto();
     await recoverPage.requestReset("not-an-email");
 
-    await expect(page.getByText(/invalid/i)).toBeVisible();
+    // Form renders "Enter a valid email address" in an `alert` slot.
+    await expect(page.getByText(/valid email/i).first()).toBeVisible();
     expect(page.url()).toContain("/recover");
   });
 });

--- a/tests/e2e/auth/register.spec.ts
+++ b/tests/e2e/auth/register.spec.ts
@@ -1,7 +1,18 @@
 import { test, expect } from "../fixtures/auth.fixture";
 
+// Skip flag for the two tests that assert the pre-Resend signup flow.
+// With RESEND_API_KEY set, Better Auth runs in
+// requireEmailVerification + enumeration-prevention mode: signup
+// returns 200 without a session and lands on a verify-pending screen,
+// and duplicate signups return synthetic success. The auth-email/*
+// suite covers the Resend path end-to-end (delivery assertions
+// included), so these UI assertions are moot when Resend is wired up.
+const skipUnderResend = !!process.env.RESEND_API_KEY;
+
 test.describe("Register", () => {
   test("registers with valid data", async ({ page, registerPage }) => {
+    test.skip(skipUnderResend, "Resend-enabled flow is covered by auth-email/* specs");
+
     const uniqueEmail = `test-${Date.now()}@example.com`;
 
     // Clear storageState so we're not already logged in
@@ -15,6 +26,8 @@ test.describe("Register", () => {
   });
 
   test("shows error for existing email", async ({ page, registerPage }) => {
+    test.skip(skipUnderResend, "Resend-enabled flow is covered by auth-email/* specs");
+
     await page.context().clearCookies();
 
     await registerPage.goto();
@@ -52,7 +65,9 @@ test.describe("Register", () => {
       "DifferentPassword!",
     );
 
-    await expect(page.getByText("Passwords do not match")).toBeVisible();
+    // The inline error and the sonner toast both render "Passwords do
+    // not match" — strict-mode needs `.first()` to pick one.
+    await expect(page.getByText("Passwords do not match").first()).toBeVisible();
     expect(page.url()).toContain("/register");
   });
 

--- a/tests/e2e/auth/reset-password.spec.ts
+++ b/tests/e2e/auth/reset-password.spec.ts
@@ -25,7 +25,9 @@ test.describe("Reset Password", () => {
     await resetPasswordPage.goto("any-token-value");
     await resetPasswordPage.submit("NewPassword123!", "DifferentPassword1!");
 
-    await expect(page.getByText(/passwords do not match/i)).toBeVisible();
+    // sr-only live region + sonner toast both render the same string —
+    // strict-mode needs `.first()`.
+    await expect(page.getByText(/passwords do not match/i).first()).toBeVisible();
     expect(page.url()).toContain("/reset-password");
   });
 

--- a/tests/e2e/helpers/test-email.ts
+++ b/tests/e2e/helpers/test-email.ts
@@ -5,9 +5,15 @@ import type { TestInfo } from "@playwright/test";
 // Resend's `delivered+<label>@resend.dev` simulates a successful delivery
 // without affecting sender reputation. The label is preserved in Resend's
 // test dashboard so failed runs can be traced back to a spec by title.
+//
+// Local-part budget (RFC 5321: 64 chars): `delivered+new-<8>-<28>` is
+// 51 chars, leaving room for the `new-` prefix the change-email spec
+// adds. GITHUB_RUN_ID is sliced to its last 8 chars so a long CI id
+// doesn't tip the address past 64 and trip Resend's "Invalid `to`
+// field" rejection.
 const makeTestEmail = (info: TestInfo): string => {
-  const slug = info.title.replaceAll(/\W+/g, "-").toLowerCase().slice(0, 40);
-  const run = process.env.GITHUB_RUN_ID ?? crypto.randomBytes(4).toString("hex");
+  const slug = info.title.replaceAll(/\W+/g, "-").toLowerCase().slice(0, 28);
+  const run = (process.env.GITHUB_RUN_ID ?? crypto.randomBytes(4).toString("hex")).slice(-8);
   return `delivered+${run}-${slug}@resend.dev`;
 };
 

--- a/tests/e2e/setup/auth.setup.ts
+++ b/tests/e2e/setup/auth.setup.ts
@@ -10,30 +10,57 @@ const TEST_USER = {
   password: "TestPassword123!",
 };
 
+const STORAGE_STATE_PATH = "tests/e2e/.auth/user.json";
+
+// Seeds storageState by signing the pre-seeded e2e user in via the auth
+// API (no browser, no form). The user itself is created by
+// `apps/web/scripts/ensure-e2e-user.ts` — that script writes directly to
+// Prisma with `emailVerified: true`, so this sign-in works even when
+// `requireEmailVerification` is on (the Resend-gated CI/prod path).
+//
+// The previous UI-form login was racy: TanStack Form's onSubmit attaches
+// after React hydrates, and Playwright clicked the submit button before
+// that landed, falling back to a native GET form submit that left the
+// user stranded on /login. API sign-in sidesteps that entirely.
 setup("create and authenticate test user", async ({ page, request }) => {
-  // Ensure .auth directory exists (fresh CI checkout won't have it)
   mkdirSync("tests/e2e/.auth", { recursive: true });
 
-  // Seed user via Better Auth (mounted at /api/auth on the web app).
-  // 201 created or 409 conflict (user already exists from a previous run) are both OK.
-  const signUpResponse = await request.post(`${webUrl}/api/auth/sign-up/email`, {
-    data: {
-      email: TEST_USER.email,
-      name: TEST_USER.name,
-      password: TEST_USER.password,
-    },
+  const signIn = await request.post(`${webUrl}/api/auth/sign-in/email`, {
+    data: { email: TEST_USER.email, password: TEST_USER.password },
   });
-  expect([200, 201, 409, 422]).toContain(signUpResponse.status());
+  expect(signIn.status()).toBe(200);
 
-  // Authenticate via the login page to get session cookies
-  await page.goto("/login");
-  await page.getByLabel("Email").fill(TEST_USER.email);
-  await page.getByLabel("Password").fill(TEST_USER.password);
-  await page.getByRole("button", { name: "Sign in" }).click();
+  // Thread the Set-Cookie headers from the API response into the browser
+  // context so dependent specs start authenticated. `headersArray()`
+  // preserves multiple Set-Cookie entries (Better Auth issues two:
+  // session_token + session_data); `headers()["set-cookie"]` flattens
+  // them into a single comma-joined string and the dot in the cookie
+  // name makes re-splitting fragile.
+  const setCookieHeaders = signIn
+    .headersArray()
+    .filter((h) => h.name.toLowerCase() === "set-cookie")
+    .map((h) => h.value);
+  const webHost = new URL(webUrl).hostname;
+  const browserCookies = [];
+  for (const part of setCookieHeaders) {
+    const [nameValue] = part.split(";");
+    const eq = nameValue.indexOf("=");
+    if (eq === -1) {
+      continue;
+    }
+    browserCookies.push({
+      domain: webHost,
+      httpOnly: true,
+      name: nameValue.slice(0, eq).trim(),
+      path: "/",
+      sameSite: "Lax" as const,
+      secure: webUrl.startsWith("https://"),
+      value: nameValue.slice(eq + 1).trim(),
+    });
+  }
+  await page.context().addCookies(browserCookies);
 
-  await page.waitForURL("/dashboard");
-  await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
-
-  // Persist auth state for browser projects
-  await page.context().storageState({ path: "tests/e2e/.auth/user.json" });
+  await page.context().storageState({ path: STORAGE_STATE_PATH });
 });
+
+export { TEST_USER };


### PR DESCRIPTION
## Summary
Acme is the template — and until now it had no CI. This lands the canonical workflow that easeia/qolmeia already use, and aligns the suite with the auth-email/* pattern standardized across the rest of the fleet.

- **\`.github/workflows/e2e.yml\`** — postgres service, pnpm install, db:generate + db:push, build, seed E2E user, playwright install, test. 45-min budget, system-deps retry loop for Ubuntu mirror flaps, playwright-report artifact upload.
- **\`apps/web/scripts/ensure-e2e-user.ts\`** — idempotent local-only Prisma seed (postgresql + localhost guard). Writes the canonical e2e-test user with \`emailVerified: true\`, bypassing Better Auth's Resend send so the user can sign in immediately even when \`requireEmailVerification\` is on.
- **\`tests/e2e/setup/auth.setup.ts\`** — API sign-in only (no UI form). Forwards Set-Cookie headers from the response into the browser context so dependent specs start authenticated. No hydration race; same shape as qolmeia and localcine.
- **\`tests/e2e/auth/register.spec.ts\` + \`auth/logout.spec.ts\`** — skip the tests that assert the pre-Resend signup flow (instant sign-in, explicit "already exists" error) when \`RESEND_API_KEY\` is set. With Resend on, Better Auth uses verify-pending + enumeration-prevention; \`auth-email/*\` covers that path with delivery assertions.
- **\`tests/e2e/auth/{register,reset-password,recovery}.spec.ts\`** — \`.first()\` on locators that match both the sr-only live region and the sonner toast; widen recovery's invalid-email regex to match the actual \`Enter a valid email address\` string.
- **\`apps/web/src/proxy.ts\`** — eslint-disable the proxy's \`console.error\` fallback (intentional server-side observability).

## Test plan
- [x] Local full chromium run: 22 passed, 4 skipped, 0 failed.
- [x] \`pnpm lint\` and \`pnpm format:check\` clean.
- [ ] First CI run on this PR — green confirms the workflow.