### PR TITLE
chore: refresh AGENTS.md and tidy chatty comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,12 +84,14 @@ The api exposes `/openapi.json`, the Scalar UI at `/docs`, and a markdown export
 ## Conventions & gotchas
 
 ### Forms
+
 - **@tanstack/react-form** (NOT react-hook-form). Validate `onBlur` + `onChange` with Zod.
 - Render errors via `field.state.meta.isTouched && !field.state.meta.isValid`.
 - Field primitives from `@repo/ui`: `Field`, `FieldGroup`, `FieldLabel`, `FieldError`.
 - **Never** put `field` in a `useEffect` / `useCallback` dependency array — it's a new object every render. Use `field.form.setFieldValue(field.name, value)` with stable refs.
 
 ### Auth
+
 - Password minimum **12 characters**. Sessions expire after 7 days.
 - `web` / `landing` use `@repo/auth/client` → calls `api` at `/auth/*`.
 - `api` uses `@repo/auth/server` with the Prisma adapter from `@repo/db`.
@@ -97,15 +99,18 @@ The api exposes `/openapi.json`, the Scalar UI at `/docs`, and a markdown export
 - `requireEmailVerification` is gated on the email-infra env vars being present (no bare `true`).
 
 ### API
+
 - Routes versioned under `/api/v1/*`. Auth at `/auth/*`. Health at `/healthz`, `/readyz`.
 - Hono app uses `@hono/structured-logger` + `@hono/zod-openapi`.
 - Build via **tsdown** (NOT tsc) — outputs to `dist/`.
 
 ### Prisma
+
 - `prisma.config.ts` uses `process.env.DATABASE_URL ?? ""` (not `env("DATABASE_URL")`) so `prisma generate` works in CI without database credentials.
 - `db:generate` is declared in `turbo.json` `build.dependsOn`, so `pnpm build` will regenerate the client before app builds.
 
 ### Tooling
+
 - Linter: **oxlint**, config in `.oxlintrc.json` via `oxlint-config-awesomeness`.
 - Formatter: **oxfmt**, config in `.oxfmtrc.json`. Sorts Tailwind classes and imports.
 - Pre-commit: Husky + lint-staged runs `oxlint` on JS/TS files and `oxfmt` on JS/TS/JSON/MD.
@@ -113,9 +118,11 @@ The api exposes `/openapi.json`, the Scalar UI at `/docs`, and a markdown export
 - Path alias: `@/*` → `src/*` in every app and package.
 
 ### Dev-only React tools
+
 - **React Scan** and **React Grab** are loaded via `<script>` in the root layout when `NODE_ENV=development`. Neither runs in production builds.
 
 ### Turbo cache keys
+
 `build.env` is sensitive to: `API_URL`, `AUTH_ALLOWED_HOSTS`, `BETTER_AUTH_SECRET`, `CORS_ORIGINS`, `DATABASE_URL`, `NEXT_PUBLIC_API_URL`, `TRUSTED_ORIGINS`, `WEB_APP_URL`. Changing any of these invalidates build cache.
 
 ## Environment

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,145 +1,162 @@
 # AGENTS.md
 
-This file provides guidance to AI coding agents when working with code in this repository.
+Guidance for AI coding agents working in `acme` — the template monorepo and source of truth for all `saas`-profile sibling projects.
 
-Project conventions and defaults are documented in [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md).
+Project conventions and defaults live in [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md).
 
-## Commands
+## Stack
+
+- **Framework:** Next.js 16 (App Router, Turbopack dev), Hono on Node 24
+- **Language:** TypeScript (strict)
+- **Styling:** Tailwind CSS v4, base-ui primitives, shadcn-style composition
+- **Database:** Prisma 7, PostgreSQL 18
+- **Auth:** Better Auth (email + password, secure cookies)
+- **Email:** Resend via `@repo/transactional` (React Email templates)
+- **Monorepo:** Turborepo + pnpm 11 workspaces (`apps/*`, `packages/*`)
+- **Lint / format:** oxlint + oxfmt (NOT ESLint / Prettier)
+- **Testing:** Vitest (unit), Playwright (e2e, chromium/firefox/webkit)
+
+## Layout
+
+```
+apps/
+  web/        Next.js — main app             https://acme.web.localhost
+  landing/    Next.js — marketing site       https://acme.landing.localhost
+  api/        Hono + tsdown — REST + auth    https://acme.api.localhost
+packages/
+  ui/                  Shared React components, TanStack Form fields, base styles
+  auth/                Better Auth config — exports ./server (api) and ./client (web/landing)
+  db/                  Prisma client singleton + schema (User, Session, Account, Verification)
+  transactional/       React Email templates + Resend sender
+  config-typescript/   Shared tsconfig bases (nextjs / server / react-library / vite)
+  config-vitest/       Shared Vitest configs (react.ts, node.ts)
+docs/                  CONVENTIONS.md + superpowers specs
+agents/counselors/     Agent role definitions
+tests/                 Root Playwright e2e specs
+docker-compose.yml     Local Postgres 18 on :5432
+```
+
+## Dev workflow
+
+Real scripts from root `package.json`:
 
 ```bash
-# Development (runs all apps concurrently via Turborepo)
-pnpm dev                          # all apps via portless
-pnpm dev --filter=web             # single app
-pnpm dev --filter=api
+pnpm dev                 # turbo dev — runs all apps behind portless concurrently
+pnpm build               # turbo run build (db:generate runs first via dependsOn)
+pnpm start               # turbo run start
+pnpm typecheck           # turbo run typecheck (tsc --noEmit per workspace)
+pnpm lint                # oxlint . at the root
+pnpm format              # oxfmt (write)
+pnpm format:check        # oxfmt --check (used in CI)
 
-# Build / Lint / Typecheck
-pnpm build                        # all packages + apps (turbo cached)
-pnpm lint                         # oxlint across all packages
-pnpm typecheck                    # tsc --noEmit across all packages
-pnpm format                       # oxfmt (write)
-pnpm format:check                 # oxfmt (check only, used in CI)
+pnpm test                # turbo run test — Vitest in every workspace
+pnpm test:e2e            # playwright test (requires web + api running)
+pnpm test:e2e:ui         # playwright with interactive UI
 
-# Testing
-pnpm test                         # vitest unit tests
-pnpm test:e2e                     # playwright (requires web + api running)
-pnpm test:e2e:ui                  # playwright with interactive UI
+pnpm db:generate         # prisma generate
+pnpm db:push             # prisma db push
+pnpm db:seed             # seed sample data
 
-# Database (Prisma, schema in packages/db/prisma/schema.prisma)
-pnpm db:generate                  # generate Prisma client
-pnpm db:push                      # push schema to database
-pnpm db:seed                      # seed database
+pnpm fallow:dead         # cross-file dead code / unused exports / cycles
+pnpm fallow:dupes        # duplicate-code detection
+pnpm fallow:health       # repo health score
+pnpm fallow:audit        # base=main audit
+pnpm clean               # turbo run clean && rm -rf node_modules
 ```
 
-## Architecture
+Per-app dev: `pnpm dev --filter=web` (or `api` / `landing`).
 
-**Monorepo** managed by pnpm workspaces + Turborepo. Node 24, pnpm 10.
+## Portless (dev URLs)
 
-### Apps
+Every app's `dev` script wraps the framework in `portless run --name <subdomain> …`, giving each one a stable HTTPS URL on `:443` instead of guessing port numbers. Cookies, OAuth redirects, and CORS allowlists stay valid across worktree switches.
 
-| App       | Framework                | Dev URL                          | Purpose                   |
-| --------- | ------------------------ | -------------------------------- | ------------------------- |
-| `web`     | Next.js 16 (App Router)  | `https://acme.web.localhost`     | Main application          |
-| `landing` | Next.js 16 (App Router)  | `https://acme.landing.localhost` | Marketing site            |
-| `api`     | Hono on Node.js (tsdown) | `https://acme.api.localhost`     | Backend API + auth server |
-
-### Packages
-
-| Package                   | Purpose                                                                                                                                |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `@repo/ui`                | Shared React components (Tailwind + CVA). Includes TanStack Form field components (`Field`, `FieldGroup`, `FieldLabel`, `FieldError`). |
-| `@repo/config-vitest`     | Shared Vitest config. Exports `react.ts` and `node.ts` configs.                                                                        |
-| `@repo/auth`              | Better Auth config. Exports `./server` (for api) and `./client` (for web/landing).                                                     |
-| `@repo/db`                | Prisma client singleton + schema. Models: User, Session, Account, Verification.                                                        |
-| `@repo/typescript-config` | Shared tsconfig bases: `nextjs.json`, `server.json`, `react-library.json`, `vite.json`.                                                |
-| `@repo/tailwind-config`   | Shared Tailwind CSS config, PostCSS config, and design tokens (`shared-styles.css`).                                                   |
-
-### Key Relationships
-
-- **Auth flow**: `web`/`landing` use `@repo/auth/client` → calls `api` at `/auth/*` → `api` uses `@repo/auth/server` with Prisma adapter from `@repo/db`.
-- **API structure**: Hono app with versioned routes (`/api/v1/*`), Better Auth at `/auth/*`, health at `/healthz` and `/readyz`.
-- **UI consumption**: `web` and `landing` both import from `@repo/ui`.
-- **Build order**: Turborepo handles `^build` dependencies — packages build before apps that depend on them.
-
-## Portless (Dev URLs)
-
-Every dev server runs behind portless, which gives each app a stable HTTPS URL on `.localhost` instead of guessing port numbers. Cookies, OAuth redirects, and CORS allowlists stay valid across project switches.
-
-### Setup (one-time per machine)
+One-time per machine:
 
 ```bash
-npm install -g portless                # global install (or upgrade)
-sudo portless proxy start --https      # start the daemon on :443
+npm install -g portless
+sudo portless proxy start --https     # binds :443, trusts the local cert
 ```
 
-The proxy auto-restarts on subsequent invocations once trusted.
+Worktrees auto-prefix the subdomain — `main` → `https://acme.web.localhost`, branch `fix-styles` → `https://fix-styles.acme.web.localhost`. Each gets an auto-assigned backing port; no collisions.
 
-### URLs
+The api exposes `/openapi.json`, the Scalar UI at `/docs`, and a markdown export at `/llms.txt` — see `apps/api/src/lib/openapi.ts`.
 
-| Service   | URL                              | Started by |
-| --------- | -------------------------------- | ---------- |
-| `web`     | `https://acme.web.localhost`     | `pnpm dev` |
-| `api`     | `https://acme.api.localhost`     | `pnpm dev` |
-| `landing` | `https://acme.landing.localhost` | `pnpm dev` |
+## Conventions & gotchas
 
-The api also exposes `/openapi.json`, the Scalar UI at `/docs`, and a markdown export at `/llms.txt` — see `apps/api/src/lib/openapi.ts`.
+### Forms
+- **@tanstack/react-form** (NOT react-hook-form). Validate `onBlur` + `onChange` with Zod.
+- Render errors via `field.state.meta.isTouched && !field.state.meta.isValid`.
+- Field primitives from `@repo/ui`: `Field`, `FieldGroup`, `FieldLabel`, `FieldError`.
+- **Never** put `field` in a `useEffect` / `useCallback` dependency array — it's a new object every render. Use `field.form.setFieldValue(field.name, value)` with stable refs.
 
-### Worktrees
+### Auth
+- Password minimum **12 characters**. Sessions expire after 7 days.
+- `web` / `landing` use `@repo/auth/client` → calls `api` at `/auth/*`.
+- `api` uses `@repo/auth/server` with the Prisma adapter from `@repo/db`.
+- `BETTER_AUTH_SECRET` must be **identical** across `apps/api/.env` and `apps/web/.env.local` — both validate sessions against it.
+- `requireEmailVerification` is gated on the email-infra env vars being present (no bare `true`).
 
-Branch name auto-prefixes the subdomain — no port collisions between concurrent worktrees, each gets its own auto-assigned backing port:
+### API
+- Routes versioned under `/api/v1/*`. Auth at `/auth/*`. Health at `/healthz`, `/readyz`.
+- Hono app uses `@hono/structured-logger` + `@hono/zod-openapi`.
+- Build via **tsdown** (NOT tsc) — outputs to `dist/`.
 
-```
-main worktree:        https://acme.web.localhost
-branch fix-styles:    https://fix-styles.acme.web.localhost
-```
+### Prisma
+- `prisma.config.ts` uses `process.env.DATABASE_URL ?? ""` (not `env("DATABASE_URL")`) so `prisma generate` works in CI without database credentials.
+- `db:generate` is declared in `turbo.json` `build.dependsOn`, so `pnpm build` will regenerate the client before app builds.
 
-## Dev Tools (Development Only)
+### Tooling
+- Linter: **oxlint**, config in `.oxlintrc.json` via `oxlint-config-awesomeness`.
+- Formatter: **oxfmt**, config in `.oxfmtrc.json`. Sorts Tailwind classes and imports.
+- Pre-commit: Husky + lint-staged runs `oxlint` on JS/TS files and `oxfmt` on JS/TS/JSON/MD.
+- Bundler for `api`: **tsdown**. Next.js apps use Turbopack in dev.
+- Path alias: `@/*` → `src/*` in every app and package.
 
-- **React Scan** — highlights unnecessary re-renders, loaded via `<script>` in root layout when `NODE_ENV=development`
-- **React Grab** — inspect React component tree, loaded via `<script>` in root layout when `NODE_ENV=development`
-- Neither tool runs in production builds
+### Dev-only React tools
+- **React Scan** and **React Grab** are loaded via `<script>` in the root layout when `NODE_ENV=development`. Neither runs in production builds.
 
-## Tooling
-
-- **Linter**: oxlint (NOT ESLint). Config in `.oxlintrc.json`. Uses `oxlint-config-awesomeness`.
-- **Formatter**: oxfmt (NOT Prettier). Config in `.oxfmtrc.json`. Sorts Tailwind classes and imports.
-- **Pre-commit**: Husky + lint-staged runs `oxlint` (on `.ts,.tsx,.js,.jsx` files) and `oxfmt` (on `.ts,.tsx,.js,.jsx,.json,.md` files).
-- **Testing**: Vitest for unit tests, Playwright for e2e (chromium, firefox, webkit). `@repo/config-vitest` exports `react.ts` and `node.ts` configs.
-- **Bundler (api)**: tsdown (not tsc). Outputs to `dist/`. Turbopack for Next.js dev.
-
-## Forms
-
-- **@tanstack/react-form** (NOT react-hook-form)
-- Validation: `onBlur` + `onChange` validators with Zod schemas
-- Display errors with `field.state.meta.isTouched && !field.state.meta.isValid`
-- Field components from `@repo/ui`: `Field`, `FieldGroup`, `FieldLabel`, `FieldError`
-- NEVER use `field.handleChange` inside `useEffect` or `useCallback` with `field` in deps — use `field.form.setFieldValue(field.name, value)` with stable refs
-
-## CI (GitHub Actions)
-
-- `test.yml` — `pnpm test`
-- `lint.yml` — `pnpm oxlint --format=github .`
-- `format.yml` — `pnpm run format:check`
-- `fallow.yml` — `pnpm fallow:dead` (cross-file dead code, unused exports, circular deps)
-- All use `permissions: { contents: read }` and `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`
-
-## Prisma
-
-`prisma.config.ts` uses `process.env.DATABASE_URL ?? ""` (not `env("DATABASE_URL")`) so `prisma generate` works in CI without database credentials.
+### Turbo cache keys
+`build.env` is sensitive to: `API_URL`, `AUTH_ALLOWED_HOSTS`, `BETTER_AUTH_SECRET`, `CORS_ORIGINS`, `DATABASE_URL`, `NEXT_PUBLIC_API_URL`, `TRUSTED_ORIGINS`, `WEB_APP_URL`. Changing any of these invalidates build cache.
 
 ## Environment
 
-Copy `.env.example` to `.env` at root. Key variables:
+Each package loads env vars from **its own** directory — there is no root `.env`.
 
-- `DATABASE_URL` — PostgreSQL connection string
-- `BETTER_AUTH_SECRET` — min 32 characters
+```bash
+cp apps/api/.env.example apps/api/.env
+cp apps/web/.env.example apps/web/.env.local
+cp packages/db/.env.example packages/db/.env
+```
+
+`apps/landing` reads no runtime env vars. Key variables:
+
+- `DATABASE_URL` — PostgreSQL connection string (matches `docker-compose.yml`: `postgres://acme:acme123@localhost:5432/acme`)
+- `BETTER_AUTH_SECRET` — min 32 chars; identical across api and web
 - `CORS_ORIGINS` / `TRUSTED_ORIGINS` — comma-separated allowed origins
-- `NEXT_PUBLIC_API_URL` — API URL for client-side requests (web/landing use this)
+- `NEXT_PUBLIC_API_URL` — API URL for client-side requests (defaults to portless URL)
+- `BETTER_AUTH_URL` — Better Auth base URL (api hostname)
 
-Web and landing apps use `.env.local` files; api uses `.env` at its app root.
+Generate `BETTER_AUTH_SECRET` with `openssl rand -base64 32`.
 
-## Conventions
+## CI (GitHub Actions)
 
-- Path aliases: `@/*` maps to `src/*` in all apps and packages.
-- Auth password minimum: 12 characters. Sessions expire after 7 days.
-- API routes are versioned under `/api/v1/`. Auth routes are at `/auth/*`.
-- Turbo caches are sensitive to `API_URL`, `AUTH_ALLOWED_HOSTS`, `NEXT_PUBLIC_API_URL`, `WEB_APP_URL`, and `DATABASE_URL`.
+Currently only `.github/workflows/e2e.yml` is checked in. Test / lint / format / fallow workflows run locally via pre-commit; expand CI as needed and keep `permissions: { contents: read }` plus `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` on any new workflow.
+
+## Notable decisions
+
+- **acme is the template.** Sibling repos (localcine, collabtime, frow, easeia) inherit every shared standard from here. Change acme first, then propagate — see `~/dev/orchestrator/standards.md`.
+- **Prisma client field** of `prisma.config.ts` deliberately falls back to `""` to keep CI green without secrets.
+- **pnpm 11 + Node 24** are the minimums (engines).
+- **No `@repo/tailwind-config` package** — Tailwind v4 reads tokens directly from `packages/ui/src/styles/globals.css` via the `@theme` directive; shared base styles also live there.
+- **base-ui (not Radix)** is the primitive layer. Wrappers in `@repo/ui` stay free of spurious `"use client"` directives.
+- **landings expose `lib/urls.ts`** with a `webAppUrl()` helper — never hardcode production URLs in marketing pages.
+
+## References
+
+- Conventions: [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md)
+- Orchestrator (cross-repo standards + verifiers): `~/dev/orchestrator`
+- Portless: <https://www.npmjs.com/package/portless>
+- Better Auth: <https://www.better-auth.com>
+- Turborepo: <https://turborepo.com>
+- Hono: <https://hono.dev>
+- React Email: <https://react.email>

--- a/apps/web/scripts/ensure-e2e-user.ts
+++ b/apps/web/scripts/ensure-e2e-user.ts
@@ -1,16 +1,5 @@
-/**
- * Idempotent LOCAL-only seed for the E2E test user. Invoked by Playwright's
- * setup spec (and CI) before any other spec runs, so the e2e suite never
- * depends on the local DB being in any particular state — nuke it,
- * re-sync, skip a step, the user will be (re)created on next run.
- *
- * NEVER point this at prod: it creates a known-password user. The
- * hard-coded `postgresql://...@localhost:...` check on DATABASE_URL is
- * the guard.
- *
- * Invoke:
- *   pnpm --filter web exec tsx scripts/ensure-e2e-user.ts
- */
+// Idempotent LOCAL-only seed for the e2e test user. The DATABASE_URL loopback
+// check below is the guard that keeps this from running against prod.
 
 import { prisma } from "@repo/db";
 
@@ -35,23 +24,16 @@ const main = async () => {
   const ctx = await getAuth().$context;
   const hashed = await ctx.password.hash(PASSWORD);
 
-  // Upsert returns the actual user row — existing users keep their
-  // original id, not SLUG — so use the returned `id` for the account FK.
+  // Existing rows keep their original id (not SLUG), so use the returned `id` for the account FK.
   const user = await prisma.user.upsert({
     create: {
       email: EMAIL,
-      // Better Auth refuses sign-in for unverified accounts when
-      // requireEmailVerification is on, so the seeded user has to land
-      // already verified. Safe because this script is local-only
-      // (DATABASE_URL guard above).
+      // requireEmailVerification blocks sign-in for unverified accounts.
       emailVerified: true,
       id: SLUG,
       name: NAME,
     },
     update: {
-      // Re-runs keep existing rows intact. Refresh the verification flag
-      // so accounts seeded before this fix get backfilled instead of
-      // staying stuck on EMAIL_NOT_VERIFIED.
       emailVerified: true,
       name: NAME,
     },

--- a/apps/web/src/app/(auth)/register/form.tsx
+++ b/apps/web/src/app/(auth)/register/form.tsx
@@ -82,11 +82,8 @@ const RegisterForm = () => {
             throw new Error("Passwords do not match");
           }
           const result = await authClient.signUp.email({
-            // Better Auth builds the verification URL from `body.callbackURL`
-            // (defaulting to "/"), NOT from `emailVerification.callbackURL`
-            // in betterAuth() config — that option is unused by the sign-up
-            // route. Sending the success page explicitly keeps the email
-            // link landing on /verify-email/success instead of /.
+            // Better Auth builds the verification URL from `body.callbackURL`;
+            // emailVerification.callbackURL config is ignored by the sign-up route.
             callbackURL: "/verify-email/success",
             email: value.email,
             name: value.name,
@@ -95,16 +92,9 @@ const RegisterForm = () => {
           if (result.error) {
             throw new Error(result.error.message ?? "Failed to register");
           }
-          // requireEmailVerification gates auto-sign-in: when active, Better
-          // Auth returns the user without a session token. Hand off email +
-          // password (in-memory only — never to storage) to the dedicated
-          // /verify-email screen, which polls signIn.email until the user
-          // clicks the verification link from their inbox. The branch also
-          // covers Better Auth's enumeration-prevention path (existing email
-          // → synthetic-success-without-token), since the screen's "check
-          // your inbox" wording is correct in both cases — the real account
-          // holder also gets a separate notification email via
-          // emailAndPassword.onExistingUserSignUp.
+          // No token → either requireEmailVerification is on, or the email
+          // already exists (enumeration prevention). Both land on the pending
+          // screen, which polls signIn.email until verification clicks through.
           if (!result.data?.token) {
             const handoff = stashCredentials({ email: value.email, password: value.password });
             push(`/verify-email?k=${handoff}`);
@@ -127,7 +117,6 @@ const RegisterForm = () => {
     <form
       noValidate
       onSubmit={(e) => {
-        // TanStack Form drives submit; progressive-enhancement N/A
         e.preventDefault();
         e.stopPropagation();
         void form.handleSubmit();

--- a/apps/web/src/app/(auth)/verify-email/pending-screen.tsx
+++ b/apps/web/src/app/(auth)/verify-email/pending-screen.tsx
@@ -31,9 +31,7 @@ type Credentials = {
 
 const PendingScreen = ({ token }: Props) => {
   const router = useRouter();
-  // useMemo so HMR / strict-mode double-mount doesn't burn the one-shot token.
-  // The store itself is idempotent on the second read (returns null), and the
-  // mounted component holds the value for the rest of its lifetime.
+  // useMemo so strict-mode double-mount doesn't burn the one-shot token.
   const initialCredentials = useMemo<Credentials | null>(
     () => (token ? consumeCredentials(token) : null),
     [token],
@@ -49,10 +47,7 @@ const PendingScreen = ({ token }: Props) => {
     };
   }, []);
 
-  // Polling — gated on `credentials` being present. Each tick attempts signIn.email;
-  // unverified accounts produce an error which we swallow and keep polling.
-  // visibilitychange pauses the timer while the tab is hidden so backgrounded
-  // tabs stop hammering the auth endpoint.
+  // Poll signIn.email until verification succeeds; pause while the tab is hidden.
   useEffect(() => {
     if (!credentials) {
       return;
@@ -90,9 +85,6 @@ const PendingScreen = ({ token }: Props) => {
       if (cancelled || document.visibilityState !== "visible") {
         return;
       }
-      // Resume by firing an immediate poll; the pending timer (if any) gets
-      // overwritten on the next schedule and harmlessly fires a stale tick
-      // that re-checks `cancelled` and bails.
       void tick();
     };
 
@@ -108,7 +100,6 @@ const PendingScreen = ({ token }: Props) => {
     };
   }, [credentials, router]);
 
-  // Resend cooldown — ticks down each second after a successful resend.
   useEffect(() => {
     if (cooldown <= 0) {
       return;

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -4,12 +4,7 @@ import awesomeness from "oxlint-config-awesomeness";
 export default defineConfig({
   extends: [awesomeness],
   overrides: [
-    // `new-cap` enforces `new` for PascalCase callables, but several frameworks
-    // expose factory functions whose names are PascalCase by convention:
-    //   - `Inter` / `Roboto` / etc. from `next/font/google`
-    //   - `Scalar` from `@scalar/hono-api-reference`
-    // The rule supports an exception list — keep it here (not in awesomeness)
-    // because the set is repo-specific.
+    // PascalCase factories from next/font/google (Inter) and @scalar/hono-api-reference (Scalar).
     {
       files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
       rules: {
@@ -21,12 +16,7 @@ export default defineConfig({
         ],
       },
     },
-    // `no-console` is on globally because shipping `console.*` to production
-    // hides errors from any structured logger. These three files are the
-    // exception: they're pre-logger error sinks for unexpected auth/proxy
-    // failures (DB down, misconfig). Without a shared logger package, the
-    // alternative is silent failure. Drop these overrides once `@repo/observability`
-    // (or similar) lands and these files migrate to it.
+    // Pre-logger error sinks for auth/proxy failures (DB down, misconfig).
     {
       files: [
         "apps/web/src/middleware.ts",
@@ -37,11 +27,7 @@ export default defineConfig({
         "no-console": "off",
       },
     },
-    // Playwright's selector engine rejects regex literals with the /v flag
-    // (e.g. `getByRole("button", { name: /sign in/iv })` fails to parse at
-    // runtime). Disable `require-unicode-regexp` for files that pass regexes
-    // to Playwright APIs so the regex flags Playwright accepts (/i without /v)
-    // can stay.
+    // Playwright's selector engine rejects /v-flagged regex literals at runtime.
     {
       files: ["tests/**", "playwright.config.ts"],
       rules: {

--- a/packages/auth/src/server.test.ts
+++ b/packages/auth/src/server.test.ts
@@ -42,9 +42,7 @@ describe("Auth Server Configuration", () => {
   });
 
   it("should gate useSecureCookies on WEB_APP_URL being HTTPS", () => {
-    // Without WEB_APP_URL the gate evaluates to false — CI runs on plain
-    // http://127.0.0.1, so cookies must not get the Secure flag (browsers
-    // drop Secure cookies on HTTP).
+    // Without WEB_APP_URL → false. Browsers drop Secure cookies on plain HTTP.
     expect(auth.options.advanced?.useSecureCookies).toBe(false);
     expect(auth.options.advanced?.defaultCookieAttributes?.httpOnly).toBe(true);
     expect(auth.options.advanced?.defaultCookieAttributes?.sameSite).toBe("lax");
@@ -132,9 +130,7 @@ describe("Auth Server Configuration", () => {
 
   it("should enable rate limiting in production", () => {
     vi.stubEnv("NODE_ENV", "production");
-    // The rateLimit gate is `production && !CI` — GitHub Actions sets
-    // CI=true on the runner, so we must clear it for the production path
-    // to evaluate true under test.
+    // Gate is `production && !CI`; clear CI so the prod path evaluates true.
     vi.stubEnv("CI", "");
     const prodAuth = createAuth({ prisma, secret: "test-secret-minimum-32-characters-long" });
     expect(prodAuth.options.rateLimit?.enabled).toBe(true);
@@ -152,10 +148,6 @@ describe("Auth Server Configuration", () => {
   });
 
   it("should always define reset password handler (no-op when resendApiKey is absent)", () => {
-    // The handler is always wired so the Better Auth /forget-password
-    // endpoint accepts the request — without an API key it just returns
-    // without sending an email, which keeps the user-visible flow working
-    // in dev/CI without email infra.
     expect(auth.options.emailAndPassword?.sendResetPassword).toBeDefined();
   });
 
@@ -188,8 +180,6 @@ describe("Auth Server Configuration", () => {
   });
 
   it("should always define verification email handler (no-op when resendApiKey is absent)", () => {
-    // Same reasoning as sendResetPassword above — endpoint accepts the
-    // request, the actual send is gated on resendApiKey at call time.
     expect(auth.options.emailVerification?.sendVerificationEmail).toBeDefined();
   });
 

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -61,27 +61,19 @@ export const createAuth = (config: AuthConfig) => {
       useSecureCookies: process.env.WEB_APP_URL?.startsWith("https://") === true,
     },
 
-    // Explicit to match the Next.js route handler mount at /api/auth/[...all].
-    // This is Better Auth's default but stated explicitly to match sibling repos.
+    // Matches the Next.js route handler mount at /api/auth/[...all].
     basePath: "/api/auth",
 
-    // Dynamic base URL: Better Auth derives the canonical origin from the
-    // incoming request when its host matches `allowedHosts`. `allowedHosts`
-    // also auto-extends `trustedOrigins`, so the explicit loopback list below
-    // only needs to cover origins that arrive without a matching host header
-    // (e.g. cross-origin CI requests where the browser sends localhost:3000
-    // but the server thinks it's :4000). See:
+    // allowedHosts auto-extends trustedOrigins; loopback list below covers
+    // origins arriving without a matching host header.
     // https://better-auth.com/docs/reference/options#dynamic-base-url
     baseURL: {
       allowedHosts: [
-        // Local dev (portless `acme.{web,api,landing}.localhost` is two
-        // labels under `.localhost`, so we need `**` not `*`). Plain
-        // loopback ports are used by CI and the API server itself.
+        // portless `acme.{web,api,landing}.localhost` is two labels under
+        // `.localhost`, so `**` not `*`.
         "**.localhost",
         "localhost:*",
         "127.0.0.1:*",
-        // Production + Vercel previews come from env so this file doesn't
-        // hardcode deployment domains.
         ...parseEnvList(process.env.AUTH_ALLOWED_HOSTS),
       ],
       fallback: "http://localhost:4000",
@@ -96,11 +88,8 @@ export const createAuth = (config: AuthConfig) => {
       enabled: true,
       maxPasswordLength: 128,
       minPasswordLength: 12,
-      // requireEmailVerification activates Better Auth's enumeration-prevention
-      // path — signing up with an already-registered email returns a synthetic
-      // success response. onExistingUserSignUp below notifies the real account
-      // holder so they're not left waiting for a verification email that won't
-      // arrive. See better-auth docs "Email Enumeration Protection".
+      // Notifies the real account holder when a duplicate signup is silently
+      // swallowed by Better Auth's enumeration-prevention path.
       onExistingUserSignUp: resendApiKey
         ? async ({ user }, request) => {
             const origin = request?.headers.get("origin") ?? "";
@@ -115,22 +104,15 @@ export const createAuth = (config: AuthConfig) => {
               { apiKey: resendApiKey, from: fromEmail },
             );
             if (!result.success) {
-              // Don't throw — Better Auth's enumeration-prevention path needs
-              // to return success regardless. Log so delivery failures don't
-              // break the auth response.
+              // Don't throw: enumeration-prevention must return success regardless.
               console.error("[Auth] Failed to send sign-up attempt email:", result.error);
             }
           }
         : undefined,
-      // Gate on Resend availability rather than NODE_ENV. If no API key is
-      // configured we physically can't send a verification email — requiring
-      // verification under that condition would lock all new users out
-      // (which is what was happening to e2e in CI before this change).
+      // Gated on Resend availability: without an API key we can't deliver,
+      // so requiring verification would lock every new user out.
       requireEmailVerification: Boolean(resendApiKey),
-      // Always defined so the Better Auth endpoint accepts the request. The
-      // actual send only happens when Resend is configured; without it we
-      // succeed silently — the test/dev environment doesn't have email infra
-      // but the user-visible flow (form submit → redirect) still works.
+      // Always wired so the endpoint accepts the request; send is gated on resendApiKey.
       sendResetPassword: async ({ url, user }) => {
         if (!resendApiKey) {
           return;
@@ -151,17 +133,10 @@ export const createAuth = (config: AuthConfig) => {
     },
 
     emailVerification: {
-      // Off: the device that clicks the verification link never receives a
-      // session cookie. The original signup tab — on any device — is the one
-      // that completes sign-in, via the /verify-email pending screen's
-      // polling. Without this, a phone-clicks-link-on-desktop-signup flow
-      // would mint a session on the phone and leave the desktop stranded.
+      // Keep the session on the original signup tab; cross-device clicks
+      // shouldn't strand the desktop by minting a session on the phone.
       autoSignInAfterVerification: false,
-      // Where Better Auth's verify-email handler redirects after token
-      // exchange. The success page renders "Email verified, you can close
-      // this page" — no session, no buttons.
       callbackURL: "/verify-email/success",
-      // Same no-op-without-Resend pattern as sendResetPassword above.
       sendVerificationEmail: async ({ url, user }) => {
         if (!resendApiKey) {
           return;
@@ -183,9 +158,7 @@ export const createAuth = (config: AuthConfig) => {
 
     plugins: [username(), bearer(), ...extraPlugins],
 
-    // Fleet-canonical rate-limit shape. CI runs production builds but the
-    // e2e suite hammers auth endpoints back-to-back across browsers; the
-    // limiter would 429 the suite, so it's gated off when CI is set.
+    // Disabled in CI: e2e suite hammers auth endpoints and would trip 429s.
     rateLimit: {
       enabled: process.env.NODE_ENV === "production" && !process.env.CI,
       max: 100,
@@ -204,10 +177,8 @@ export const createAuth = (config: AuthConfig) => {
       storeSessionInDatabase: true,
       updateAge: 60 * 60 * 24, // Update session if older than 1 day
     },
-    // `allowedHosts` already feeds `trustedOrigins`; the loopback set below
-    // covers exact-origin checks for plain `http://localhost:PORT` requests
-    // that wouldn't match a host pattern (Better Auth's origin check is
-    // exact-string for trustedOrigins).
+    // Exact-string match list for plain http://localhost:PORT origins that
+    // wouldn't match an allowedHosts pattern.
     trustedOrigins: [
       "http://localhost:3000",
       "http://localhost:3001",
@@ -227,11 +198,8 @@ export const createAuth = (config: AuthConfig) => {
       },
       changeEmail: {
         enabled: true,
-        // Two-step flow: sendChangeEmailConfirmation goes to the CURRENT email
-        // for consent. When the link is clicked, Better Auth re-invokes
-        // emailVerification.sendVerificationEmail (the signup-verification hook
-        // above) targeting the NEW email to confirm mailbox ownership. Same
-        // no-op-without-Resend pattern as the other hooks.
+        // Stage 1 of the two-step change flow: confirmation to the CURRENT email.
+        // Stage 2 (verification to the NEW email) reuses sendVerificationEmail above.
         sendChangeEmailConfirmation: async ({ newEmail, url, user }) => {
           if (!resendApiKey) {
             return;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,8 +28,7 @@ export default defineConfig({
   fullyParallel: true,
   globalTeardown: "./tests/e2e/teardown/cleanup.ts",
 
-  // CI runs chromium only — chromium is the canonical Playwright signal;
-  // firefox + webkit run locally / nightly.
+  // CI: chromium only. firefox + webkit run locally / nightly.
   projects: [
     { name: "setup", testMatch: /.*\.setup\.ts/v },
     {
@@ -73,12 +72,8 @@ export default defineConfig({
     video: "retain-on-failure",
   },
 
-  // CI spawns three webServers in parallel. Wrapping each in `pnpm --filter`
-  // serializes them on pnpm's workspace state lock — the first wins, the
-  // rest hang silently for the full timeout. Run the binaries directly so
-  // each spawn is independent. Pnpm hoists shared bins to the repo-root
-  // `node_modules/.bin/`, so we reference them from there and pass the app
-  // directory as an arg to `next start`.
+  // Spawn binaries directly: `pnpm --filter` would serialize the three webServers
+  // on pnpm's workspace lock and the losers hang silently.
   webServer: process.env.CI
     ? [
         {
@@ -86,9 +81,7 @@ export default defineConfig({
           stderr: "pipe",
           stdout: "pipe",
           timeout: 120_000,
-          // Probe `/login` (returns 200) — web has no `/` route, so probing the
-          // root URL would 404 forever and Playwright would never proceed to
-          // spawn the api/landing webServers.
+          // Web has no `/` route; probe /login so readiness detection lands a 200.
           url: `${webUrl}/login`,
         },
         {

--- a/tests/e2e/auth-email/change-email.spec.ts
+++ b/tests/e2e/auth-email/change-email.spec.ts
@@ -8,9 +8,8 @@ import { makeTestEmail, makeTestUsername } from "../helpers/test-email";
 
 test.skip(!process.env.RESEND_API_KEY, "needs RESEND_API_KEY (test mode)");
 
-// auth-email specs seed their own users and bypass the storageState the rest
-// of the suite relies on — they need a clean cookie jar so the signup POST
-// isn't rejected as "already signed in".
+// Clean cookie jar: this spec seeds its own user; the shared storageState
+// session would make the signup POST 400 as "already signed in".
 test.use({ storageState: { cookies: [], origins: [] } });
 
 test.describe("Change email (two-stage confirmation + verification)", () => {
@@ -25,30 +24,21 @@ test.describe("Change email (two-stage confirmation + verification)", () => {
     const username = makeTestUsername(currentEmail);
     const password = "ChangeEmailPwd1!";
 
-    // Seed + verify a user, then sign in to get a session. Welcome email isn't
-    // under test here; reuse the JWT-reconstruction path.
+    // Welcome email isn't under test; use JWT reconstruction for the verify step.
     const signUp = await request.post(`${webUrl}/api/auth/sign-up/email`, {
       data: { email: currentEmail, name: "Change Me", password, username },
     });
     expect([200, 201]).toContain(signUp.status());
     const verify = await verification.forVerifyEmail(currentEmail);
     await page.goto(verify.url);
-    // forVerifyEmail builds a callbackURL=/verify-email/success URL, and the
-    // verify-email handler runs with autoSignInAfterVerification: false — so
-    // the click lands on /verify-email/success without setting a session
-    // cookie. Sign in explicitly to attach the session for the change-email
-    // request below.
+    // autoSignInAfterVerification is off, so the verify click sets no cookie.
     await page.waitForURL(/\/verify-email\/success$/v);
     const signIn = await request.post(`${webUrl}/api/auth/sign-in/email`, {
       data: { email: currentEmail, password },
     });
     expect(signIn.status()).toBe(200);
 
-    // Parse Set-Cookie from the sign-in response and forward as Cookie on the
-    // change-email call. Playwright's APIRequestContext storage state doesn't
-    // include cookies set via API responses, so we have to thread the cookie
-    // through manually. Better Auth issues a single `__Secure-<prefix>.
-    // session_token` cookie marked HttpOnly/Secure/SameSite=Lax.
+    // Playwright's APIRequestContext doesn't persist API-set cookies, so thread Set-Cookie manually.
     const setCookie = signIn.headers()["set-cookie"] ?? "";
     const cookieHeader = setCookie
       .split(/,(?=\s*[\w-]+=)/u)
@@ -56,9 +46,7 @@ test.describe("Change email (two-stage confirmation + verification)", () => {
       .filter(Boolean)
       .join("; ");
 
-    // Also seed the session cookie into the browser context so the later
-    // page.goto(stage1Url/stage2Url) calls have an authenticated session
-    // and the proxy doesn't bounce them to /login.
+    // Seed cookies into the browser context too, so the later page.goto() calls are authed.
     const webHost = new URL(webUrl).hostname;
     const parsedCookies = setCookie
       .split(/,(?=\s*[\w-]+=)/u)

--- a/tests/e2e/auth-email/existing-user-signup.spec.ts
+++ b/tests/e2e/auth-email/existing-user-signup.spec.ts
@@ -24,14 +24,10 @@ test.describe("Sign-up for an existing email (enumeration prevention)", () => {
     });
     expect([200, 201]).toContain(first.status());
 
-    // Pin AFTER the first signup so the welcome mail doesn't match the
-    // sign-up-attempt assertion below.
+    // Pin AFTER the first signup so its welcome mail doesn't match below.
     const since = Date.now();
 
-    // Second sign-up with same email — Better Auth's enumeration-prevention
-    // returns the same shape as a fresh signup; `onExistingUserSignUp` fires
-    // server-side and dispatches a "someone tried to sign up" notification
-    // to the real account holder.
+    // Duplicate email → synthetic success; onExistingUserSignUp fires server-side.
     const second = await request.post(`${webUrl}/api/auth/sign-up/email`, {
       data: {
         email,
@@ -48,8 +44,6 @@ test.describe("Sign-up for an existing email (enumeration prevention)", () => {
     expect(users[0]?.name).toBe("Original Name");
 
     // Side-effect floor: the notification email actually went out via Resend.
-    // Without this assertion, a regression that disabled the hook would pass
-    // the test silently — exactly the bug class we're trying to catch.
     const mail = await waitForEmail({
       sinceMs: since,
       subject: /sign[\s-]?up|attempt|tried/i,

--- a/tests/e2e/auth-email/password-reset.spec.ts
+++ b/tests/e2e/auth-email/password-reset.spec.ts
@@ -21,9 +21,7 @@ test.describe("Password reset", () => {
     const originalPassword = "OriginalPassword1!";
     const newPassword = "BrandNewPassword2!";
 
-    // Seed a user via the API. Bypass verification with the JWT-reconstruction
-    // helper — delivery of the *welcome* email isn't under test here. (See
-    // sign-up-verification.spec.ts for that assertion.)
+    // Welcome-email delivery isn't under test here; use JWT reconstruction.
     const signUp = await request.post(`${webUrl}/api/auth/sign-up/email`, {
       data: { email, name: "Reset Me", password: originalPassword, username },
     });
@@ -32,20 +30,16 @@ test.describe("Password reset", () => {
     await page.goto(verify.url);
     await page.context().clearCookies();
 
-    // Pin the cutoff AFTER the welcome email was sent so we don't pick it up
-    // when looking for the password-reset mail.
+    // Pin cutoff AFTER the welcome email so the reset-mail search doesn't match it.
     const since = Date.now();
 
-    // Request reset. Better Auth's endpoint is `/request-password-reset`
-    // (the older `/forget-password` path was removed). Always returns 200
-    // here (enumeration prevention) regardless of whether the email exists.
+    // Always 200 (enumeration prevention) regardless of whether the email exists.
     const reset = await request.post(`${webUrl}/api/auth/request-password-reset`, {
       data: { email, redirectTo: "/reset-password" },
     });
     expect(reset.status()).toBe(200);
 
-    // Assert the reset email actually left Resend — this is the bug class
-    // "we sent a 200 but never delivered" that the old DB-poll path missed.
+    // Assert the reset email actually left Resend (200 with no send is the regression).
     const mail = await waitForEmail({
       sinceMs: since,
       subject: /reset/i,
@@ -53,19 +47,14 @@ test.describe("Password reset", () => {
     });
     expect(mail.last_event).not.toBe("bounced");
 
-    // Better Auth builds `${baseURL}/reset-password/<token>?callbackURL=<redirectTo>`
-    // (token is a path segment, not a query param). The endpoint validates and
-    // redirects to the UI's `/reset-password?token=...`.
+    // Better Auth builds `/reset-password/<token>?callbackURL=...` (token is a path segment).
     const resetUrl = extractLink(mail, /\/reset-password\/[^"?]+\?callbackURL=/v);
     await page.goto(resetUrl);
 
-    // The reset page reads token from query. Fill new password.
     await page.getByLabel("New password", { exact: true }).fill(newPassword);
     await page.getByLabel(/confirm password/i).fill(newPassword);
     await page.getByRole("button", { name: /reset password/i }).click();
 
-    // After reset, Better Auth lands the user back on /login (the form's
-    // success path); old password should fail, new password should succeed.
     await page.waitForURL(/\/login/);
 
     await page.getByLabel("Email").fill(email);

--- a/tests/e2e/auth-email/sign-up-verification.spec.ts
+++ b/tests/e2e/auth-email/sign-up-verification.spec.ts
@@ -4,9 +4,6 @@ import { webUrl } from "../../../playwright.config";
 import { extractLink, waitForEmail } from "../helpers/resend";
 import { makeTestEmail, makeTestUsername } from "../helpers/test-email";
 
-// Skip the whole suite when Resend isn't configured. Without RESEND_API_KEY,
-// the auth server runs with requireEmailVerification: false, which is a
-// different code path — these tests would assert against the wrong behavior.
 test.skip(!process.env.RESEND_API_KEY, "needs RESEND_API_KEY (test mode)");
 
 test.use({ storageState: { cookies: [], origins: [] } });
@@ -40,9 +37,7 @@ test.describe("Sign-up email verification", () => {
     });
     expect(preSignIn.status()).not.toBe(200);
 
-    // Assert the verification email actually left Resend. This is the
-    // regression we care about: "JWT format was valid but the email never
-    // sent" silently passed the old reconstruction-based path.
+    // Assert the verification email actually left Resend (not just that the JWT was valid).
     const mail = await waitForEmail({
       sinceMs: since,
       subject: /verify/i,
@@ -50,11 +45,8 @@ test.describe("Sign-up email verification", () => {
     });
     expect(mail.last_event).not.toBe("bounced");
 
-    // Pull the verification URL out of the rendered HTML and follow it in a
-    // fresh BrowserContext (cross-device click). With
-    // autoSignInAfterVerification: false, this lands on the success page
-    // WITHOUT creating a session in the clicker context — the polling tab
-    // elsewhere is the one that completes sign-in.
+    // Follow the link in a fresh context (cross-device click); autoSignInAfterVerification
+    // is off, so this lands on /success without minting a session for the clicker.
     const verifyUrl = extractLink(mail, /\/api\/auth\/verify-email\?token=/v);
     const clickerContext = await browser.newContext();
     const clickerPage = await clickerContext.newPage();
@@ -65,8 +57,7 @@ test.describe("Sign-up email verification", () => {
     expect(clickerCookies.find((c) => c.name.startsWith("acme."))).toBeUndefined();
     await clickerContext.close();
 
-    // Original-tab path: signIn now succeeds. Polling client-side does this
-    // continuously; the test just exercises the same code path once.
+    // Original-tab path: signIn now succeeds (the polling pending screen does this in a loop).
     const postSignIn = await request.post(`${webUrl}/api/auth/sign-in/email`, {
       data: { email, password },
     });

--- a/tests/e2e/auth/logout.spec.ts
+++ b/tests/e2e/auth/logout.spec.ts
@@ -5,11 +5,8 @@ import { expect, test } from "../fixtures/auth.fixture";
 
 const PASSWORD = "TestPassword123!";
 
-// Logout invalidates the session row in the database. If these tests reused the
-// shared `e2e-test@acme.localhost` user from the setup project, the moment one
-// of them ran, every other test sharing that storageState would 401 once the
-// 5-minute Better Auth cookie cache expired (packages/auth/src/server.ts:193).
-// So each logout test owns a freshly created user instead.
+// Logout invalidates the DB session row; reusing the shared storageState user
+// would 401 every other spec once Better Auth's 5-minute cookie cache expires.
 const createIsolatedUser = async (request: APIRequestContext): Promise<string> => {
   const email = `logout-test-${crypto.randomUUID()}@acme.localhost`;
   const response = await request.post(`${webUrl}/api/auth/sign-up/email`, {
@@ -19,11 +16,8 @@ const createIsolatedUser = async (request: APIRequestContext): Promise<string> =
   return email;
 };
 
-// With RESEND_API_KEY set, requireEmailVerification flips on and a
-// fresh-signup-then-sign-in flow can't land at /dashboard — the user
-// stays on the verify-pending screen. The auth-email/* suite covers
-// the Resend path; these UI logout assertions belong to the
-// no-Resend local-dev path.
+// With RESEND_API_KEY set, requireEmailVerification blocks fresh-signup → /dashboard;
+// the auth-email/* suite covers that path.
 const skipUnderResend = !!process.env.RESEND_API_KEY;
 
 test.describe("Logout", () => {

--- a/tests/e2e/auth/register.spec.ts
+++ b/tests/e2e/auth/register.spec.ts
@@ -1,12 +1,7 @@
 import { test, expect } from "../fixtures/auth.fixture";
 
-// Skip flag for the two tests that assert the pre-Resend signup flow.
-// With RESEND_API_KEY set, Better Auth runs in
-// requireEmailVerification + enumeration-prevention mode: signup
-// returns 200 without a session and lands on a verify-pending screen,
-// and duplicate signups return synthetic success. The auth-email/*
-// suite covers the Resend path end-to-end (delivery assertions
-// included), so these UI assertions are moot when Resend is wired up.
+// With RESEND_API_KEY set, requireEmailVerification gates signup → /dashboard;
+// the auth-email/* suite covers that path with delivery assertions.
 const skipUnderResend = !!process.env.RESEND_API_KEY;
 
 test.describe("Register", () => {
@@ -15,7 +10,6 @@ test.describe("Register", () => {
 
     const uniqueEmail = `test-${Date.now()}@example.com`;
 
-    // Clear storageState so we're not already logged in
     await page.context().clearCookies();
 
     await registerPage.goto();
@@ -48,8 +42,7 @@ test.describe("Register", () => {
     await registerPage.goto();
     await registerPage.register("Short Pass", `short-${Date.now()}@example.com`, "short", "short");
 
-    // Both password and confirmPassword fields render the same length
-    // error, so .first() avoids a strict-mode "resolved to 2 elements" violation.
+    // Both password fields render the same error; .first() avoids strict-mode 2-element violation.
     await expect(page.getByText(/at least 12 characters/i).first()).toBeVisible();
     expect(page.url()).toContain("/register");
   });
@@ -65,8 +58,7 @@ test.describe("Register", () => {
       "DifferentPassword!",
     );
 
-    // The inline error and the sonner toast both render "Passwords do
-    // not match" — strict-mode needs `.first()` to pick one.
+    // Inline error + sonner toast both render the same string; .first() picks one for strict-mode.
     await expect(page.getByText("Passwords do not match").first()).toBeVisible();
     expect(page.url()).toContain("/register");
   });

--- a/tests/e2e/fixtures/verification.fixture.ts
+++ b/tests/e2e/fixtures/verification.fixture.ts
@@ -18,29 +18,17 @@ const requireSecret = (): string => {
   return secret;
 };
 
-// Builds the verify-email JWT Better Auth would have signed for `email`.
-// Better Auth doesn't persist this token — it's a pure HS256 JWT of
-// `{email}` keyed with the auth secret. Reconstructing it lets tests skip
-// inbox polling entirely. See node_modules/better-auth/dist/api/routes/
-// email-verification.mjs:createEmailVerificationToken.
+// Reconstructs the HS256 JWT (`{email}` signed with the auth secret) that
+// Better Auth would have emailed, so tests can skip inbox polling.
 const forVerifyEmail = async (email: string): Promise<{ token: string; url: string }> => {
   const token = await signJWT({ email: email.toLowerCase() }, requireSecret(), 3600);
-  // Matches @repo/auth's emailVerification.callbackURL — the verify-email
-  // handler redirects here after token exchange, and (with
-  // autoSignInAfterVerification: false) does so without setting a session
-  // cookie on the device that clicked the link.
   const callbackURL = encodeURIComponent("/verify-email/success");
   const url = `${webUrl}/api/auth/verify-email?token=${token}&callbackURL=${callbackURL}`;
   return { token, url };
 };
 
-// Two-stage change-email flow. Stage 1 (`change-email-confirmation`) goes to
-// CURRENT email and proves consent; clicking it triggers stage 2
-// (`change-email-verification`) sent to NEW email which actually updates
-// the user record. Both JWTs share email/updateTo/secret — only requestType
-// differs — so we reconstruct both up-front and let the test drive each
-// click independently. See update-user.mjs:466-490 and
-// email-verification.mjs:177-200.
+// Two-stage change-email JWTs share email/updateTo/secret; only requestType
+// differs (confirmation → current mailbox, verification → new mailbox).
 type ChangeEmailUrls = {
   confirmationToken: string;
   confirmationUrl: string;
@@ -75,10 +63,8 @@ const forChangeEmail = async (currentEmail: string, newEmail: string): Promise<C
   };
 };
 
-// Password reset uses a random token persisted in the verification table —
-// NOT a JWT — so the fixture polls the DB. Better Auth writes the row
-// synchronously in the `/forget-password` handler, so a tight poll loop
-// converges within a few hundred ms (default timeout still generous).
+// Reset uses a random token persisted in the verification table (not a JWT),
+// so this polls the DB; Better Auth writes the row synchronously.
 const forResetPassword = async (
   email: string,
   timeoutMs = 5000,
@@ -93,8 +79,6 @@ const forResetPassword = async (
   const deadline = Date.now() + timeoutMs;
   let lastError: string | undefined;
 
-  // Polling is intentionally sequential — we're waiting for a DB row to
-  // appear, so parallelizing wouldn't help.
   while (Date.now() < deadline) {
     // eslint-disable-next-line no-await-in-loop
     const row = await prisma.verification.findFirst({

--- a/tests/e2e/helpers/resend.ts
+++ b/tests/e2e/helpers/resend.ts
@@ -1,18 +1,6 @@
-// Resend test-inbox client used by the auth-email specs to assert that
-// transactional emails were actually sent (and not silently dropped by a
-// regressed sender, missing API key, schema-validation rejection, etc.).
-//
-// Why poll the live API instead of reconstructing JWTs locally:
-// reconstruction proves the token format is correct, but says NOTHING about
-// whether the email left our infrastructure. We've been bitten by that —
-// "the JWT was valid but the email never sent" is the bug class this helper
-// catches. The JWT/DB-poll path in `verification.fixture.ts` remains useful
-// for tests where delivery isn't under test (e.g. seeding a verified user
-// before a different scenario).
-//
-// All sends in e2e use `delivered+<label>@resend.dev` (see helpers/test-email.ts).
-// Resend short-circuits delivery for these addresses but still records the
-// send in the API, so `GET /emails` lists them in test-mode runs.
+// Polls Resend's `GET /emails` so specs can assert mails actually left the API,
+// catching "JWT valid but send never happened" regressions that JWT
+// reconstruction in verification.fixture.ts can't see.
 
 const RESEND_API = "https://api.resend.com";
 
@@ -53,14 +41,8 @@ const requireApiKey = (): string => {
   return key;
 };
 
-// Resend caps the team at 5 req/s and returns 429 with a `retry-after`
-// header (seconds) when the suite bursts past that. Parallel auth-email
-// specs reliably trip it — every test polls `GET /emails` at 1Hz, so 4
-// workers × spec startup hits the ceiling. Mirrors vercel/fetch-retry's
-// defaults (factor 6, 5 retries, max retry-after 20s) so behavior matches
-// the most-deployed reference for this pattern. See
-// https://resend.com/docs/api-reference/rate-limit and
-// https://github.com/vercel/fetch-retry/blob/master/index.js.
+// Resend caps the team at 5 req/s; parallel specs polling at 1Hz trip 429s.
+// Defaults mirror vercel/fetch-retry (factor 6, 5 retries, retry-after cap 20s).
 const RETRY_MAX_ATTEMPTS = 5;
 const RETRY_MAX_RETRY_AFTER_SECONDS = 20;
 const RETRY_BASE_MS = 200;

--- a/tests/e2e/setup/auth.setup.ts
+++ b/tests/e2e/setup/auth.setup.ts
@@ -12,16 +12,8 @@ const TEST_USER = {
 
 const STORAGE_STATE_PATH = "tests/e2e/.auth/user.json";
 
-// Seeds storageState by signing the pre-seeded e2e user in via the auth
-// API (no browser, no form). The user itself is created by
-// `apps/web/scripts/ensure-e2e-user.ts` — that script writes directly to
-// Prisma with `emailVerified: true`, so this sign-in works even when
-// `requireEmailVerification` is on (the Resend-gated CI/prod path).
-//
-// The previous UI-form login was racy: TanStack Form's onSubmit attaches
-// after React hydrates, and Playwright clicked the submit button before
-// that landed, falling back to a native GET form submit that left the
-// user stranded on /login. API sign-in sidesteps that entirely.
+// API sign-in (not UI form) avoids the TanStack Form hydration race where
+// Playwright clicks before onSubmit attaches and falls back to a native GET.
 setup("create and authenticate test user", async ({ page, request }) => {
   mkdirSync("tests/e2e/.auth", { recursive: true });
 
@@ -30,12 +22,8 @@ setup("create and authenticate test user", async ({ page, request }) => {
   });
   expect(signIn.status()).toBe(200);
 
-  // Thread the Set-Cookie headers from the API response into the browser
-  // context so dependent specs start authenticated. `headersArray()`
-  // preserves multiple Set-Cookie entries (Better Auth issues two:
-  // session_token + session_data); `headers()["set-cookie"]` flattens
-  // them into a single comma-joined string and the dot in the cookie
-  // name makes re-splitting fragile.
+  // headersArray() preserves multiple Set-Cookie entries; headers()["set-cookie"]
+  // flattens them and the dot in the cookie name makes re-splitting fragile.
   const setCookieHeaders = signIn
     .headersArray()
     .filter((h) => h.name.toLowerCase() === "set-cookie")


### PR DESCRIPTION
## Summary
- Refreshed AGENTS.md via /init pass; CLAUDE.md kept as a symlink to it.
- Tidied chatty / explanatory / historical comments per the project comment rules (no WHAT, only essential non-obvious WHY).

## Test plan
- [ ] Skim AGENTS.md for accuracy
- [ ] Skim diff for any comment that lost essential context