### PR TITLE
fix(api): drop nullable type lie from AuthVariables

### DIFF
--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -22,10 +22,8 @@ import { createMockContext } from "./test-helpers";
 const mockSession = {
   session: { id: "session-1" },
   user: {
-    displayName: "Test User",
     email: "test@example.com",
     id: "user-1",
-    username: "testuser",
   },
 };
 
@@ -43,10 +41,8 @@ describe("authMiddleware", () => {
     await authMiddleware(ctx, next);
 
     expect(mocks.set).toHaveBeenCalledWith("user", {
-      displayName: "Test User",
       email: "test@example.com",
       id: "user-1",
-      username: "testuser",
     });
     expect(next).toHaveBeenCalled();
   });
@@ -113,10 +109,8 @@ describe("optionalAuthMiddleware", () => {
     await optionalAuthMiddleware(ctx, next);
 
     expect(mocks.set).toHaveBeenCalledWith("user", {
-      displayName: "Test User",
       email: "test@example.com",
       id: "user-1",
-      username: "testuser",
     });
     expect(next).toHaveBeenCalled();
   });

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -6,10 +6,8 @@ import { auth } from "../lib/auth";
 
 export type AuthVariables = {
   user: {
-    displayName?: string;
     email: string;
     id: string;
-    username?: string;
   };
 };
 
@@ -51,10 +49,8 @@ export const authMiddleware = createMiddleware<{ Variables: AuthVariables }>(
     }
 
     c.set("user", {
-      displayName: session.user.displayName,
       email: session.user.email,
       id: session.user.id,
-      username: session.user.username,
     });
 
     await next();
@@ -71,10 +67,8 @@ export const optionalAuthMiddleware = createMiddleware<{
 
     if (session && session.user) {
       c.set("user", {
-        displayName: session.user.displayName,
         email: session.user.email,
         id: session.user.id,
-        username: session.user.username,
       });
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
- `displayName` and `username` were typed `?: string` in `AuthVariables.user` but the Prisma schema declares them nullable (`String?` at `packages/db/prisma/schema.prisma:20,22`), so the middleware wrote `null` into a `string` slot at runtime.
- All five consumers of `c.get("user")` (`apps/api/src/routes/v1/users.ts` and `apps/api/src/middleware/security.ts`) only read `user.id` — the route at `/me` already re-fetches the full user via `findUserById(user.id)`.
- Dropping the two columns from the request context removes the lie before it propagates to every downstream saas repo.

## Test plan
- [x] `pnpm typecheck` — 9/9 passing
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format:check` — clean
- [ ] CI green

Identified by thermo-nuclear audit (`docs/superpowers/audits/thermo-2026-06-05/acme.md` item #4 in the orchestrator).