### PR TITLE
refactor(api): delete redundant try/catch around prisma in users.ts

### DIFF
--- a/apps/api/src/lib/users.test.ts
+++ b/apps/api/src/lib/users.test.ts
@@ -15,10 +15,6 @@ vi.mock("@/lib/env", () => ({
   env: { NODE_ENV: "test" },
 }));
 
-vi.mock("@/lib/logger", () => ({
-  logger: { error: vi.fn(), info: vi.fn() },
-}));
-
 import { prisma } from "@repo/db";
 
 import { AppError } from "@/middleware/error-handler";
@@ -35,6 +31,9 @@ const mockUser = {
   updatedAt: new Date("2024-01-01"),
   username: "testuser",
 };
+
+const prismaKnownError = (code: string) =>
+  Object.assign(new Error("Prisma error"), { clientVersion: "7.0.0", code });
 
 describe("findUserById", () => {
   beforeEach(() => {
@@ -62,14 +61,11 @@ describe("findUserById", () => {
     });
   });
 
-  it("throws AppError 500 on database error", async () => {
-    vi.mocked(prisma.user.findUnique).mockRejectedValue(new Error("DB connection lost"));
+  it("propagates database errors to the central error handler", async () => {
+    const dbError = new Error("DB connection lost");
+    vi.mocked(prisma.user.findUnique).mockRejectedValue(dbError);
 
-    await expect(findUserById("user-1")).rejects.toThrow(AppError);
-    await expect(findUserById("user-1")).rejects.toMatchObject({
-      code: "USER_FETCH_ERROR",
-      statusCode: 500,
-    });
+    await expect(findUserById("user-1")).rejects.toThrow(dbError);
   });
 });
 
@@ -94,13 +90,11 @@ describe("findUserByEmail", () => {
     expect(result).toBeNull();
   });
 
-  it("throws AppError 500 on database error", async () => {
-    vi.mocked(prisma.user.findUnique).mockRejectedValue(new Error("DB error"));
+  it("propagates database errors to the central error handler", async () => {
+    const dbError = new Error("DB error");
+    vi.mocked(prisma.user.findUnique).mockRejectedValue(dbError);
 
-    await expect(findUserByEmail("test@example.com")).rejects.toMatchObject({
-      code: "USER_FETCH_ERROR",
-      statusCode: 500,
-    });
+    await expect(findUserByEmail("test@example.com")).rejects.toThrow(dbError);
   });
 });
 
@@ -135,26 +129,20 @@ describe("updateUser", () => {
     expect(prisma.user.findFirst).not.toHaveBeenCalled();
   });
 
-  it("throws AppError 404 on P2025 error", async () => {
+  it("propagates P2025 to the central error handler", async () => {
     vi.mocked(prisma.user.findFirst).mockResolvedValue(null as never);
-    vi.mocked(prisma.user.update).mockRejectedValue(
-      Object.assign(new Error("Record not found"), { clientVersion: "7.0.0", code: "P2025" }),
-    );
+    const notFound = prismaKnownError("P2025");
+    vi.mocked(prisma.user.update).mockRejectedValue(notFound);
 
-    await expect(updateUser("missing", { name: "X" })).rejects.toMatchObject({
-      code: "USER_NOT_FOUND",
-      statusCode: 404,
-    });
+    await expect(updateUser("missing", { name: "X" })).rejects.toMatchObject({ code: "P2025" });
   });
 
-  it("throws AppError 500 on generic database error", async () => {
+  it("propagates generic database errors to the central error handler", async () => {
     vi.mocked(prisma.user.findFirst).mockResolvedValue(null as never);
-    vi.mocked(prisma.user.update).mockRejectedValue(new Error("Connection refused"));
+    const dbError = new Error("Connection refused");
+    vi.mocked(prisma.user.update).mockRejectedValue(dbError);
 
-    await expect(updateUser("user-1", { name: "X" })).rejects.toMatchObject({
-      code: "USER_UPDATE_ERROR",
-      statusCode: 500,
-    });
+    await expect(updateUser("user-1", { name: "X" })).rejects.toThrow(dbError);
   });
 });
 
@@ -172,23 +160,17 @@ describe("deleteUser", () => {
     expect(prisma.user.delete).toHaveBeenCalledWith({ where: { id: "user-1" } });
   });
 
-  it("throws AppError 404 on P2025 error", async () => {
-    vi.mocked(prisma.user.delete).mockRejectedValue(
-      Object.assign(new Error("Record not found"), { clientVersion: "7.0.0", code: "P2025" }),
-    );
+  it("propagates P2025 to the central error handler", async () => {
+    const notFound = prismaKnownError("P2025");
+    vi.mocked(prisma.user.delete).mockRejectedValue(notFound);
 
-    await expect(deleteUser("missing")).rejects.toMatchObject({
-      code: "USER_NOT_FOUND",
-      statusCode: 404,
-    });
+    await expect(deleteUser("missing")).rejects.toMatchObject({ code: "P2025" });
   });
 
-  it("throws AppError 500 on generic database error", async () => {
-    vi.mocked(prisma.user.delete).mockRejectedValue(new Error("DB error"));
+  it("propagates generic database errors to the central error handler", async () => {
+    const dbError = new Error("DB error");
+    vi.mocked(prisma.user.delete).mockRejectedValue(dbError);
 
-    await expect(deleteUser("user-1")).rejects.toMatchObject({
-      code: "USER_DELETE_ERROR",
-      statusCode: 500,
-    });
+    await expect(deleteUser("user-1")).rejects.toThrow(dbError);
   });
 });

--- a/apps/api/src/lib/users.ts
+++ b/apps/api/src/lib/users.ts
@@ -1,8 +1,7 @@
 import { prisma } from "@repo/db";
 import type { Prisma } from "@repo/db";
 
-import { logger } from "@/lib/logger";
-import { AppError, isPrismaKnownError } from "@/middleware/error-handler";
+import { AppError } from "@/middleware/error-handler";
 
 const userSelect = {
   createdAt: true,
@@ -16,92 +15,49 @@ const userSelect = {
 } satisfies Prisma.UserSelect;
 
 export const findUserById = async (id: string) => {
-  try {
-    const user = await prisma.user.findUnique({
-      select: userSelect,
-      where: { id },
-    });
+  const user = await prisma.user.findUnique({
+    select: userSelect,
+    where: { id },
+  });
 
-    if (!user) {
-      throw new AppError("User not found", 404, true, "USER_NOT_FOUND");
-    }
-
-    return user;
-  } catch (error) {
-    if (error instanceof AppError) {
-      throw error;
-    }
-
-    logger.error({ error, userId: id }, "Failed to find user by ID");
-    throw new AppError("Failed to fetch user", 500, false, "USER_FETCH_ERROR");
+  if (!user) {
+    throw new AppError("User not found", 404, true, "USER_NOT_FOUND");
   }
+
+  return user;
 };
 
-export const findUserByEmail = async (email: string) => {
-  try {
-    return await prisma.user.findUnique({
-      select: userSelect,
-      where: { email },
-    });
-  } catch (error) {
-    logger.error({ email, error }, "Failed to find user by email");
-    throw new AppError("Failed to fetch user", 500, false, "USER_FETCH_ERROR");
-  }
-};
+export const findUserByEmail = (email: string) =>
+  prisma.user.findUnique({
+    select: userSelect,
+    where: { email },
+  });
 
 export const updateUser = async (id: string, data: Prisma.UserUpdateInput) => {
-  try {
-    if (typeof data.username === "string") {
-      const existing = await prisma.user.findFirst({
-        where: {
-          NOT: { id },
-          username: data.username,
-        },
-      });
-
-      if (existing) {
-        throw new AppError("Username already taken", 400, true, "USERNAME_TAKEN");
-      }
-    }
-
-    const updatedUser = await prisma.user.update({
-      data,
-      select: userSelect,
-      where: { id },
+  if (typeof data.username === "string") {
+    const existing = await prisma.user.findFirst({
+      where: {
+        NOT: { id },
+        username: data.username,
+      },
     });
 
-    logger.info({ fields: Object.keys(data), userId: id }, "User updated successfully");
-
-    return updatedUser;
-  } catch (error) {
-    if (error instanceof AppError) {
-      throw error;
+    if (existing) {
+      throw new AppError("Username already taken", 400, true, "USERNAME_TAKEN");
     }
-
-    if (isPrismaKnownError(error) && error.code === "P2025") {
-      throw new AppError("User not found", 404, true, "USER_NOT_FOUND");
-    }
-
-    logger.error({ error, userId: id }, "Failed to update user");
-    throw new AppError("Failed to update user", 500, false, "USER_UPDATE_ERROR");
   }
+
+  return prisma.user.update({
+    data,
+    select: userSelect,
+    where: { id },
+  });
 };
 
 export const deleteUser = async (id: string) => {
-  try {
-    await prisma.user.delete({
-      where: { id },
-    });
+  await prisma.user.delete({
+    where: { id },
+  });
 
-    logger.info({ userId: id }, "User deleted successfully");
-
-    return { success: true };
-  } catch (error) {
-    if (isPrismaKnownError(error) && error.code === "P2025") {
-      throw new AppError("User not found", 404, true, "USER_NOT_FOUND");
-    }
-
-    logger.error({ error, userId: id }, "Failed to delete user");
-    throw new AppError("Failed to delete user", 500, false, "USER_DELETE_ERROR");
-  }
+  return { success: true };
 };


### PR DESCRIPTION
## Summary
- Every fn in `apps/api/src/lib/users.ts` wrapped prisma calls in `try/catch` to translate P2025 → 404 and unknown → 500, but `apps/api/src/middleware/error-handler.ts:81-105` already does exactly that with env-aware leak protection.
- Kept the two intentional throws: AppError USER_NOT_FOUND when findUnique returns null (prisma does not throw P2025 here), and AppError USERNAME_TAKEN on the precheck.
- Tests updated to assert that prisma errors propagate raw, with the central handler responsible for HTTP translation.

## Behavior change
Response error codes change from per-domain `USER_*` codes to the central handler's `NOT_FOUND` / `DUPLICATE_ENTRY` / `INTERNAL_SERVER_ERROR`. No production consumers — acme is the template, downstream repos haven't shipped these yet, so fixing the template prevents the "invent a per-domain ERROR_CODE" ritual from propagating.

## Test plan
- [x] `pnpm typecheck` — 9/9 passing
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format:check` — clean
- [x] `pnpm test --filter=api` — 53/53 passing (14 in users.test.ts)
- [ ] CI green

Identified by thermo-nuclear audit (`docs/superpowers/audits/thermo-2026-06-05/acme.md` item #2 in the orchestrator).