### PR TITLE
refactor(transactional): collapse senders into template registry

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -1,10 +1,6 @@
 import type { PrismaClient } from "@repo/db";
-import {
-  sendChangeEmailConfirmation,
-  sendPasswordResetEmail,
-  sendSignUpAttemptEmail,
-  sendWelcomeEmail,
-} from "@repo/transactional";
+import type { MailerConfig } from "@repo/transactional";
+import { sendTransactionalEmail } from "@repo/transactional";
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { bearer } from "better-auth/plugins/bearer";
@@ -41,6 +37,10 @@ export const createAuth = (config: AuthConfig) => {
     resendApiKey,
     secret,
   } = config;
+
+  const mailer: MailerConfig | null = resendApiKey
+    ? { apiKey: resendApiKey, from: fromEmail }
+    : null;
 
   return betterAuth({
     account: {
@@ -90,18 +90,19 @@ export const createAuth = (config: AuthConfig) => {
       minPasswordLength: 12,
       // Notifies the real account holder when a duplicate signup is silently
       // swallowed by Better Auth's enumeration-prevention path.
-      onExistingUserSignUp: resendApiKey
+      onExistingUserSignUp: mailer
         ? async ({ user }, request) => {
             const origin = request?.headers.get("origin") ?? "";
-            const result = await sendSignUpAttemptEmail(
+            const result = await sendTransactionalEmail(
               {
                 resetPasswordUrl: `${origin}/recover`,
                 signInUrl: `${origin}/login`,
+                type: "sign-up-attempt",
                 userEmail: user.email,
                 userId: user.id,
                 username: user.name,
               },
-              { apiKey: resendApiKey, from: fromEmail },
+              mailer,
             );
             if (!result.success) {
               // Don't throw: enumeration-prevention must return success regardless.
@@ -111,20 +112,21 @@ export const createAuth = (config: AuthConfig) => {
         : undefined,
       // Gated on Resend availability: without an API key we can't deliver,
       // so requiring verification would lock every new user out.
-      requireEmailVerification: Boolean(resendApiKey),
-      // Always wired so the endpoint accepts the request; send is gated on resendApiKey.
+      requireEmailVerification: Boolean(mailer),
+      // Always wired so the endpoint accepts the request; send is gated on mailer.
       sendResetPassword: async ({ url, user }) => {
-        if (!resendApiKey) {
+        if (!mailer) {
           return;
         }
-        const result = await sendPasswordResetEmail(
+        const result = await sendTransactionalEmail(
           {
             resetUrl: url,
+            type: "password-reset",
             userEmail: user.email,
             userId: user.id,
             username: user.name,
           },
-          { apiKey: resendApiKey, from: fromEmail },
+          mailer,
         );
         if (!result.success) {
           throw new Error(`Failed to send password reset email: ${result.error}`);
@@ -138,17 +140,18 @@ export const createAuth = (config: AuthConfig) => {
       autoSignInAfterVerification: false,
       callbackURL: "/verify-email/success",
       sendVerificationEmail: async ({ url, user }) => {
-        if (!resendApiKey) {
+        if (!mailer) {
           return;
         }
-        const result = await sendWelcomeEmail(
+        const result = await sendTransactionalEmail(
           {
+            type: "welcome",
             userEmail: user.email,
             userId: user.id,
             username: user.name,
             verificationUrl: url,
           },
-          { apiKey: resendApiKey, from: fromEmail },
+          mailer,
         );
         if (!result.success) {
           throw new Error(`Failed to send verification email: ${result.error}`);
@@ -201,18 +204,19 @@ export const createAuth = (config: AuthConfig) => {
         // Stage 1 of the two-step change flow: confirmation to the CURRENT email.
         // Stage 2 (verification to the NEW email) reuses sendVerificationEmail above.
         sendChangeEmailConfirmation: async ({ newEmail, url, user }) => {
-          if (!resendApiKey) {
+          if (!mailer) {
             return;
           }
-          const result = await sendChangeEmailConfirmation(
+          const result = await sendTransactionalEmail(
             {
               changeUrl: url,
               currentEmail: user.email,
               newEmail,
+              type: "change-email-confirmation",
               userId: user.id,
               username: user.name,
             },
-            { apiKey: resendApiKey, from: fromEmail },
+            mailer,
           );
           if (!result.success) {
             throw new Error(`Failed to send change-email confirmation: ${result.error}`);

--- a/packages/transactional/src/index.ts
+++ b/packages/transactional/src/index.ts
@@ -6,12 +6,8 @@ export { Divider } from "./components/divider";
 
 // Utilities
 export { sendEmail, sendBatchEmails, previewEmail } from "./lib/send-email";
-export {
-  sendChangeEmailConfirmation,
-  sendWelcomeEmail,
-  sendPasswordResetEmail,
-  sendSignUpAttemptEmail,
-} from "./lib/senders";
+export type { MailerConfig, TransactionalEmail } from "./lib/senders";
+export { sendTransactionalEmail } from "./lib/senders";
 
 // Theme
 export { emailTheme, tailwindConfig } from "./styles/theme";

--- a/packages/transactional/src/lib/senders.ts
+++ b/packages/transactional/src/lib/senders.ts
@@ -7,7 +7,7 @@ import { WelcomeEmail } from "../emails/welcome";
 
 import { sendEmail } from "./send-email";
 
-type EmailConfig = {
+type MailerConfig = {
   apiKey: string;
   defaultReplyTo?: string;
   from?: string;
@@ -15,102 +15,70 @@ type EmailConfig = {
 
 const DEFAULT_FROM = "Acme <noreply@acme.com>";
 
-// These wrappers return `sendEmail`'s promise directly. Keeping them sync
-// avoids a useless extra microtask; callers `await` them either way.
-const sendWelcomeEmail = (
-  {
-    userEmail,
-    userId,
-    username,
-    verificationUrl,
-  }: {
-    userEmail: string;
-    userId: string;
-    username?: string;
-    verificationUrl: string;
-  },
-  config: EmailConfig,
-) => {
-  return sendEmail({
-    apiKey: config.apiKey,
-    defaultReplyTo: config.defaultReplyTo,
-    from: config.from || DEFAULT_FROM,
-    subject: `Welcome to Acme${username ? `, ${username}` : ""}! Please verify your email`,
-    tags: [
-      { name: "type", value: "welcome" },
-      { name: "userId", value: userId },
-    ],
-    template: React.createElement(WelcomeEmail, {
-      userEmail,
-      username,
-      verificationUrl,
-    }),
-    to: userEmail,
-  });
+type WelcomePayload = {
+  userEmail: string;
+  userId: string;
+  username?: string;
+  verificationUrl: string;
 };
 
-const sendSignUpAttemptEmail = (
-  {
-    resetPasswordUrl,
-    signInUrl,
-    userEmail,
-    userId,
-    username,
-  }: {
-    resetPasswordUrl: string;
-    signInUrl: string;
-    userEmail: string;
-    userId: string;
-    username?: string;
-  },
-  config: EmailConfig,
-) => {
-  return sendEmail({
-    apiKey: config.apiKey,
-    defaultReplyTo: config.defaultReplyTo,
-    from: config.from || DEFAULT_FROM,
-    subject: "Sign-up attempt with your Acme account",
-    tags: [
-      { name: "type", value: "sign-up-attempt" },
-      { name: "userId", value: userId },
-    ],
-    template: React.createElement(SignUpAttemptEmail, {
-      resetPasswordUrl,
-      signInUrl,
-      userEmail,
-      username,
-    }),
-    to: userEmail,
-  });
+type SignUpAttemptPayload = {
+  resetPasswordUrl: string;
+  signInUrl: string;
+  userEmail: string;
+  userId: string;
+  username?: string;
 };
 
-const sendPasswordResetEmail = (
-  {
+type PasswordResetPayload = {
+  browserInfo?: string;
+  ipAddress?: string;
+  resetUrl: string;
+  userEmail: string;
+  userId: string;
+  username?: string;
+};
+
+type ChangeEmailPayload = {
+  changeUrl: string;
+  currentEmail: string;
+  newEmail: string;
+  userId: string;
+  username?: string;
+};
+
+type TransactionalEmail =
+  | ({ type: "welcome" } & WelcomePayload)
+  | ({ type: "sign-up-attempt" } & SignUpAttemptPayload)
+  | ({ type: "password-reset" } & PasswordResetPayload)
+  | ({ type: "change-email-confirmation" } & ChangeEmailPayload);
+
+type EmailBuild = { subject: string; template: React.ReactElement; to: string };
+
+type TemplateBuilder<P> = (payload: P) => EmailBuild;
+
+// Adding a new transactional email = one new payload type + one entry below.
+const TEMPLATES = {
+  "change-email-confirmation": ({
+    changeUrl,
+    currentEmail,
+    newEmail,
+    username,
+  }: ChangeEmailPayload) => ({
+    subject: "Confirm change of your Acme account email",
+    template: React.createElement(ChangeEmail, { changeUrl, currentEmail, newEmail, username }),
+    // `to: currentEmail` is the consent step. Better Auth's sendVerificationEmail
+    // hook handles the mailbox-ownership step to the NEW email when clicked.
+    to: currentEmail,
+  }),
+  "password-reset": ({
     browserInfo,
     ipAddress,
     resetUrl,
     userEmail,
-    userId,
     username,
-  }: {
-    browserInfo?: string;
-    ipAddress?: string;
-    resetUrl: string;
-    userEmail: string;
-    userId: string;
-    username?: string;
-  },
-  config: EmailConfig,
-) => {
-  return sendEmail({
-    apiKey: config.apiKey,
-    defaultReplyTo: config.defaultReplyTo,
-    from: config.from || DEFAULT_FROM,
+  }: PasswordResetPayload) => ({
     subject: "Reset your Acme password",
-    tags: [
-      { name: "type", value: "password-reset" },
-      { name: "userId", value: userId },
-    ],
     template: React.createElement(PasswordResetEmail, {
       browserInfo,
       ipAddress,
@@ -119,50 +87,52 @@ const sendPasswordResetEmail = (
       username,
     }),
     to: userEmail,
-  });
+  }),
+  "sign-up-attempt": ({
+    resetPasswordUrl,
+    signInUrl,
+    userEmail,
+    username,
+  }: SignUpAttemptPayload) => ({
+    subject: "Sign-up attempt with your Acme account",
+    template: React.createElement(SignUpAttemptEmail, {
+      resetPasswordUrl,
+      signInUrl,
+      userEmail,
+      username,
+    }),
+    to: userEmail,
+  }),
+  welcome: ({ userEmail, username, verificationUrl }: WelcomePayload) => ({
+    subject: `Welcome to Acme${username ? `, ${username}` : ""}! Please verify your email`,
+    template: React.createElement(WelcomeEmail, { userEmail, username, verificationUrl }),
+    to: userEmail,
+  }),
+} satisfies {
+  "change-email-confirmation": TemplateBuilder<ChangeEmailPayload>;
+  "password-reset": TemplateBuilder<PasswordResetPayload>;
+  "sign-up-attempt": TemplateBuilder<SignUpAttemptPayload>;
+  welcome: TemplateBuilder<WelcomePayload>;
 };
 
-const sendChangeEmailConfirmation = (
-  {
-    changeUrl,
-    currentEmail,
-    newEmail,
-    userId,
-    username,
-  }: {
-    changeUrl: string;
-    currentEmail: string;
-    newEmail: string;
-    userId: string;
-    username?: string;
-  },
-  config: EmailConfig,
-) => {
+const sendTransactionalEmail = (email: TransactionalEmail, config: MailerConfig) => {
+  // The `type` discriminator keys directly into TEMPLATES; TS narrows the payload
+  // shape per branch, but the lookup itself is structural.
+  const builder = TEMPLATES[email.type] as TemplateBuilder<typeof email>;
+  const { subject, template, to } = builder(email);
   return sendEmail({
     apiKey: config.apiKey,
     defaultReplyTo: config.defaultReplyTo,
     from: config.from || DEFAULT_FROM,
-    subject: "Confirm change of your Acme account email",
+    subject,
     tags: [
-      { name: "type", value: "change-email-confirmation" },
-      { name: "userId", value: userId },
+      { name: "type", value: email.type },
+      { name: "userId", value: email.userId },
     ],
-    template: React.createElement(ChangeEmail, {
-      changeUrl,
-      currentEmail,
-      newEmail,
-      username,
-    }),
-    // Send to CURRENT email — this is the consent step. Better Auth's
-    // sendVerificationEmail hook handles the second mailbox-ownership step
-    // to the NEW email when the confirmation link is clicked.
-    to: currentEmail,
+    template,
+    to,
   });
 };
 
-export {
-  sendChangeEmailConfirmation,
-  sendWelcomeEmail,
-  sendPasswordResetEmail,
-  sendSignUpAttemptEmail,
-};
+export type { MailerConfig, TransactionalEmail };
+export { sendTransactionalEmail };


### PR DESCRIPTION
## Summary
- Four near-identical sender functions (`sendWelcomeEmail`, `sendSignUpAttemptEmail`, `sendPasswordResetEmail`, `sendChangeEmailConfirmation`) collapsed into one `sendTransactionalEmail(email, mailer)` dispatcher driven by a typed `TEMPLATES` record keyed by a `TransactionalEmail` discriminated union.
- Adding a new email type now = one new payload type + one entry in the record (instead of: declare fn, export, import, callsite).
- Hoisted `mailer: MailerConfig | null` to a single constant at the top of `createAuth` in `packages/auth/src/server.ts`. Each callback gates on `if (!mailer) return;`.
- Net diff: 118 insertions, 148 deletions across `senders.ts`, `transactional/src/index.ts`, `auth/src/server.ts`.

## Why
acme is the saas template — the four-copies-of-the-same-30-LOC-skeleton pattern propagates to every downstream saas repo unless absorbed here. The registry pattern is the canonical structure the audit called for.

## Test plan
- [x] `pnpm typecheck` — 9/9 passing
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format:check` — clean
- [x] `pnpm test` — 10/10 passing (web + api + transactional + auth)
- [ ] CI green
- [ ] e2e auth-email suite (covers welcome, password-reset, change-email-confirmation, sign-up-attempt)

Identified by thermo-nuclear audit (`docs/superpowers/audits/thermo-2026-06-05/acme.md` item #3 in the orchestrator).