### PR TITLE
fix(db): seed loads its own .env so `pnpm db:seed` works standalone

### DIFF
--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1,3 +1,5 @@
+import "dotenv/config";
+
 import { prisma } from ".";
 
 const DEFAULT_USERS = [


### PR DESCRIPTION
## Problem
`pnpm db:seed` fails locally with `SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string` unless `DATABASE_URL` is already exported in the shell.

`packages/db/src/seed.ts` imports the Prisma client, which reads `process.env.DATABASE_URL` at construction (`new PrismaPg({ connectionString: process.env.DATABASE_URL })`). The `db:seed` script runs `tsx src/seed.ts` **directly**, bypassing `prisma.config.ts`'s `import "dotenv/config"` — so `packages/db/.env` is never loaded and the connection string is empty.

## Fix
Add `import "dotenv/config"` as the first import of `seed.ts` (matching frow's already-working seed). `dotenv` does **not** override variables already present in `process.env`, so CI (which injects `DATABASE_URL`) is unaffected.

## Verification
- `env -u DATABASE_URL pnpm db:seed` → succeeds (previously failed), seeds `john@doe.com` + `jane@doe.com`.
- `pnpm --filter @repo/db lint` → 0 warnings, 0 errors.