### PR TITLE
chore: fleet alignment — actions @v6, tool bumps, verify-email credentials-store, typecheck coverage

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -6,11 +6,15 @@
   "entry": [
     "oxlint.config.ts",
     "**/prisma.config.ts",
+    "apps/web/scripts/ensure-e2e-user.ts",
+    "apps/*/src/lib/observability.ts",
     "packages/transactional/src/emails/**/*.tsx"
   ],
   "ignorePatterns": ["verify-auth.js", "tests/e2e/setup/auth.setup.ts"],
   "ignoreDependencies": [
     "eslint-plugin-*",
+    "better-auth",
+    "hono",
     "@tailwindcss/postcss",
     "postcss",
     "postcss-load-config",

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       CI: true
       DATABASE_URL: postgresql://test:test@localhost:5432/test
       BETTER_AUTH_SECRET: test-secret-minimum-32-characters-long-for-e2e
@@ -45,9 +44,9 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: pnpm

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -1,0 +1,19 @@
+name: Fallow
+on:
+  push:
+    branches: [main]
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  dead-code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm fallow:dead

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,19 @@
+name: Format
+on:
+  push:
+    branches: [main]
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  oxfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run format:check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+on:
+  push:
+    branches: [main]
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  oxlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm oxlint --format=github .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test
+on:
+  push:
+    branches: [main]
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  vitest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm lint-staged

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Monorepo template for all projects. Source of truth for shared patterns, tooling
 ### Prerequisites
 
 - **Node.js 24** (use `nvm install 24 && nvm use 24`)
-- **pnpm 10** (`npm install -g pnpm@10`)
+- **pnpm 11** (`npm install -g pnpm@11`)
 - **PostgreSQL** running locally on `:5432` (or use Docker — see below)
 - **portless** for stable HTTPS dev URLs (see step 2)
 

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -54,7 +54,7 @@ export const authMiddleware = createMiddleware<{ Variables: AuthVariables }>(
       id: session.user.id,
     });
 
-    await next();
+    return next();
   },
 );
 
@@ -81,5 +81,5 @@ export const optionalAuthMiddleware = createMiddleware<{
     });
   }
 
-  await next();
+  return next();
 });

--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -5,7 +5,7 @@ import { ZodError } from "zod";
 
 import { env } from "@/lib/env";
 
-export const isPrismaKnownError = (
+const isPrismaKnownError = (
   err: unknown,
 ): err is InstanceType<typeof Prisma.PrismaClientKnownRequestError> =>
   err instanceof Error && "code" in err && "clientVersion" in err;

--- a/apps/api/src/middleware/security.ts
+++ b/apps/api/src/middleware/security.ts
@@ -86,6 +86,6 @@ export const requestSizeLimit = (maxSize: number = 10 * 1024 * 1024) => {
       );
     }
 
-    await next();
+    return await next();
   };
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,6 +31,7 @@
     "@repo/config-vitest": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@tailwindcss/postcss": "^4.3.0",
+    "@testing-library/react": "^16.3.2",
     "@total-typescript/ts-reset": "^0.6.1",
     "@types/node": "^25.6.2",
     "@types/react": "^19.2.14",

--- a/apps/web/src/app/(auth)/register/form.tsx
+++ b/apps/web/src/app/(auth)/register/form.tsx
@@ -17,6 +17,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 
+import { stashCredentials } from "@/app/(auth)/verify-email/credentials-store";
 import { authClient } from "@/lib/auth-client";
 import { registerSchema } from "@/lib/form-schemas";
 
@@ -91,13 +92,11 @@ const RegisterForm = () => {
           if (result.error) {
             throw new Error(result.error.message ?? "Failed to register");
           }
-          // No token → either requireEmailVerification is on, or the email
-          // already exists (enumeration prevention). Both land on the pending
-          // screen with the email pre-filled for the resend button. The
-          // verification link itself is what signs the user in, via Better
-          // Auth's autoSignInAfterVerification.
+          // No token means requireEmailVerification suppressed auto-sign-in (or enumeration prevention
+          // returned synthetic success); both paths route to /verify-email with the same "check inbox" UX.
           if (!result.data?.token) {
-            push(`/verify-email?email=${encodeURIComponent(value.email)}`);
+            const handoff = stashCredentials({ email: value.email, password: value.password });
+            push(`/verify-email?k=${handoff}`);
             return;
           }
           push("/dashboard");

--- a/apps/web/src/app/(auth)/verify-email/credentials-store.test.ts
+++ b/apps/web/src/app/(auth)/verify-email/credentials-store.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  consumeCredentials,
+  resetCredentialsStoreForTests,
+  stashCredentials,
+} from "./credentials-store";
+
+describe("credentials-store", () => {
+  afterEach(() => {
+    resetCredentialsStoreForTests();
+  });
+
+  it("issues a token and returns the stashed credentials exactly once", () => {
+    const token = stashCredentials({ email: "a@b.com", password: "pw-12345678" });
+    expect(consumeCredentials(token)).toEqual({ email: "a@b.com", password: "pw-12345678" });
+    expect(consumeCredentials(token)).toBeNull();
+  });
+
+  it("returns null for an unknown token", () => {
+    expect(consumeCredentials("not-a-real-token")).toBeNull();
+  });
+
+  it("issues a different token per stash", () => {
+    const t1 = stashCredentials({ email: "a@b.com", password: "pw-12345678" });
+    const t2 = stashCredentials({ email: "c@d.com", password: "pw-87654321" });
+    expect(t1).not.toBe(t2);
+  });
+});

--- a/apps/web/src/app/(auth)/verify-email/credentials-store.ts
+++ b/apps/web/src/app/(auth)/verify-email/credentials-store.ts
@@ -1,0 +1,38 @@
+// Module-level in-memory store for the {email, password} handoff between the
+// signup form and the /verify-email pending screen. Lives only in this JS
+// context — wiped on full page reload, never written to disk, never reachable
+// from another tab. The pending screen reads via `consumeCredentials` which
+// removes the entry on first read.
+
+type Credentials = {
+  email: string;
+  password: string;
+};
+
+const store = new Map<string, Credentials>();
+
+const newToken = (): string =>
+  globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+
+const stashCredentials = (credentials: Credentials): string => {
+  const token = newToken();
+  store.set(token, credentials);
+  return token;
+};
+
+const consumeCredentials = (token: string): Credentials | null => {
+  const credentials = store.get(token);
+  if (!credentials) {
+    return null;
+  }
+  store.delete(token);
+  return credentials;
+};
+
+// Test-only escape hatch — vitest's per-test isolation doesn't reset module
+// state, and exporting this is cheaper than mocking the module.
+const resetCredentialsStoreForTests = () => {
+  store.clear();
+};
+
+export { consumeCredentials, resetCredentialsStoreForTests, stashCredentials };

--- a/apps/web/src/app/(auth)/verify-email/page.tsx
+++ b/apps/web/src/app/(auth)/verify-email/page.tsx
@@ -8,11 +8,11 @@ export const metadata: Metadata = {
   title: "Verify your email",
 };
 
-type SearchParams = Promise<{ email?: string }>;
+type SearchParams = Promise<{ k?: string }>;
 
 const VerifyEmailPage = async ({ searchParams }: { searchParams: SearchParams }) => {
-  const { email } = await searchParams;
-  return <PendingScreen email={email ?? null} />;
+  const { k } = await searchParams;
+  return <PendingScreen token={k ?? null} />;
 };
 
 export default VerifyEmailPage;

--- a/apps/web/src/app/(auth)/verify-email/pending-screen.test.tsx
+++ b/apps/web/src/app/(auth)/verify-email/pending-screen.test.tsx
@@ -1,29 +1,41 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+import { resetCredentialsStoreForTests, stashCredentials } from "./credentials-store";
 import PendingScreen from "./pending-screen";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
 
 vi.mock("@/lib/auth-client", () => ({
   authClient: {
     sendVerificationEmail: vi.fn(() => Promise.resolve({ data: null, error: null })),
+    signIn: {
+      email: vi.fn(() => Promise.resolve({ data: null, error: { message: "not verified" } })),
+    },
   },
 }));
 
 describe("PendingScreen", () => {
-  it("renders the fallback when no email is in the URL", () => {
-    render(<PendingScreen email={null} />);
-    // getByRole throws if missing — its return implies "in the document".
-    screen.getByRole("heading", { name: /check your inbox/iv });
+  it("renders the stale-tab fallback when no credentials token is in the URL", () => {
+    resetCredentialsStoreForTests();
+    render(<PendingScreen token={null} />);
+    // getByText throws if missing — its return implies "in the document".
+    // @repo/ui's CardTitle isn't always a heading element in this fleet, so
+    // text-based lookup is portable across the apps' UI package versions.
+    screen.getByText(/verifying your email/iv);
     const link = screen.getByRole("link", { name: /sign in/iv });
     expect(link.getAttribute("href")).toBe("/login");
   });
 
-  it("renders the email + resend button when email is present", () => {
-    render(<PendingScreen email="user@example.com" />);
+  it("renders the polling state with the stashed email when credentials are present", () => {
+    resetCredentialsStoreForTests();
+    const token = stashCredentials({ email: "user@example.com", password: "pw-12345678" });
+    render(<PendingScreen token={token} />);
     screen.getByText("user@example.com");
     const resend = screen.getByRole("button", { name: /resend verification email/iv });
     expect(resend.hasAttribute("disabled")).toBe(false);
-    const signIn = screen.getByRole("link", { name: /sign in/iv });
-    expect(signIn.getAttribute("href")).toBe("/login");
   });
 });

--- a/apps/web/src/app/(auth)/verify-email/pending-screen.tsx
+++ b/apps/web/src/app/(auth)/verify-email/pending-screen.tsx
@@ -10,20 +10,99 @@ import {
   CardTitle,
 } from "@repo/ui/components/card";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { authClient } from "@/lib/auth-client";
 
+import { consumeCredentials } from "./credentials-store";
+
+const POLL_INTERVAL_MS = 5000;
 const RESEND_COOLDOWN_SECONDS = 60;
 
 type Props = {
-  email: string | null;
+  token: string | null;
 };
 
-const PendingScreen = ({ email }: Props) => {
+type Credentials = {
+  email: string;
+  password: string;
+};
+
+const PendingScreen = ({ token }: Props) => {
+  const router = useRouter();
+  // useMemo so HMR / strict-mode double-mount doesn't burn the one-shot token.
+  // The store itself is idempotent on the second read (returns null), and the
+  // mounted component holds the value for the rest of its lifetime.
+  const initialCredentials = useMemo<Credentials | null>(
+    () => (token ? consumeCredentials(token) : null),
+    [token],
+  );
+  const [credentials] = useState<Credentials | null>(initialCredentials);
   const [cooldown, setCooldown] = useState(0);
   const [isResending, setIsResending] = useState(false);
 
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  // Pause polling when the tab is hidden so backgrounded tabs don't hammer the auth endpoint.
+  useEffect(() => {
+    if (!credentials) {
+      return;
+    }
+    const { email, password } = credentials;
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const tick = async () => {
+      if (cancelled) {
+        return;
+      }
+      if (document.visibilityState !== "visible") {
+        timer = setTimeout(() => {
+          void tick();
+        }, POLL_INTERVAL_MS);
+        return;
+      }
+      const result = await authClient.signIn.email({ email, password });
+      if (cancelled || !isMountedRef.current) {
+        return;
+      }
+      if (!result.error && result.data) {
+        router.push("/dashboard");
+        router.refresh();
+        return;
+      }
+      timer = setTimeout(() => {
+        void tick();
+      }, POLL_INTERVAL_MS);
+    };
+
+    const onVisibility = () => {
+      if (cancelled || document.visibilityState !== "visible") {
+        return;
+      }
+      void tick();
+    };
+
+    document.addEventListener("visibilitychange", onVisibility);
+    void tick();
+
+    return () => {
+      cancelled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [credentials, router]);
+
+  // Resend cooldown — ticks down each second after a successful resend.
   useEffect(() => {
     if (cooldown <= 0) {
       return;
@@ -36,29 +115,29 @@ const PendingScreen = ({ email }: Props) => {
     };
   }, [cooldown]);
 
-  const handleResend = async () => {
-    if (!email || cooldown > 0 || isResending) {
+  const onResend = useCallback(async () => {
+    if (!credentials || cooldown > 0 || isResending) {
       return;
     }
     setIsResending(true);
     try {
       await authClient.sendVerificationEmail({
         callbackURL: "/verify-email/success",
-        email,
+        email: credentials.email,
       });
       setCooldown(RESEND_COOLDOWN_SECONDS);
     } finally {
       setIsResending(false);
     }
-  };
+  }, [cooldown, credentials, isResending]);
 
-  if (!email) {
+  if (!credentials) {
     return (
       <Card>
         <CardHeader className="text-center">
-          <CardTitle className="text-xl">Check your inbox</CardTitle>
+          <CardTitle className="text-xl">Verifying your email</CardTitle>
           <CardDescription>
-            Click the verification link we sent to finish signing up, then sign in below.
+            Click the verification link from your inbox. Once you do, sign in to continue.
           </CardDescription>
         </CardHeader>
         <CardFooter className="flex flex-col gap-2">
@@ -76,8 +155,8 @@ const PendingScreen = ({ email }: Props) => {
         <CardTitle className="text-xl">Check your inbox</CardTitle>
         <CardDescription>
           We sent a verification link to{" "}
-          <span className="font-medium text-foreground">{email}</span>. Click it to verify, then
-          sign in.
+          <span className="font-medium text-foreground">{credentials.email}</span>. Click it to
+          finish signing in — this page will continue automatically.
         </CardDescription>
       </CardHeader>
       <CardContent className="text-center text-sm text-muted-foreground">
@@ -88,16 +167,13 @@ const PendingScreen = ({ email }: Props) => {
           className="w-full"
           disabled={cooldown > 0 || isResending}
           onClick={() => {
-            void handleResend();
+            void onResend();
           }}
           type="button"
           variant="outline"
         >
           {cooldown > 0 ? `Resend in ${cooldown}s` : "Resend verification email"}
         </Button>
-        <Link className={buttonVariants({ className: "w-full" })} href="/login">
-          Sign in
-        </Link>
         <Link
           className="text-sm text-muted-foreground underline-offset-4 hover:underline"
           href="/register"

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -26,7 +26,11 @@ export const proxy = async (request: NextRequest) => {
     .catch((error) => {
       // Auth service failure (DB down, misconfiguration, etc.) — log so outages
       // are observable, then treat as unauthenticated to keep the pipeline moving.
-      log.error({ error, message: "proxy: getSession failed — treating as unauthenticated", pathname });
+      log.error({
+        error,
+        message: "proxy: getSession failed — treating as unauthenticated",
+        pathname,
+      });
       return null;
     });
 

--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "@repo/db": "workspace:*",
-    "fallow": "^2.69.0",
+    "better-auth": "^1.6.10",
+    "fallow": "^2.85.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.4",
-    "oxfmt": "^0.48.0",
-    "oxlint": "^1.63.0",
+    "oxfmt": "^0.52.0",
+    "oxlint": "^1.67.0",
     "oxlint-config-awesomeness": "^3.0.2",
     "turbo": "^2.9.12"
   },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "lint": "oxlint src",
-    "type-check": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"

--- a/packages/auth/src/server.test.ts
+++ b/packages/auth/src/server.test.ts
@@ -196,8 +196,8 @@ describe("Auth Server Configuration", () => {
     expect(auth.options.emailVerification?.callbackURL).toBe("/verify-email/success");
   });
 
-  it("enables autoSignInAfterVerification so the verification link mints a session", () => {
-    expect(auth.options.emailVerification?.autoSignInAfterVerification).toBe(true);
+  it("disables autoSignInAfterVerification so the link-clicker device stays sessionless", () => {
+    expect(auth.options.emailVerification?.autoSignInAfterVerification).toBe(false);
   });
 
   it("should have displayName as optional additional user field", () => {

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -139,7 +139,15 @@ export const createAuth = (config: AuthConfig) => {
     },
 
     emailVerification: {
-      autoSignInAfterVerification: true,
+      // Off: the device that clicks the verification link never receives a
+      // session cookie. The original signup tab — on any device — is the one
+      // that completes sign-in, via the /verify-email pending screen's
+      // polling. Without this, a phone-clicks-link-on-desktop-signup flow
+      // would mint a session on the phone and leave the desktop stranded.
+      autoSignInAfterVerification: false,
+      // Where Better Auth's verify-email handler redirects after token
+      // exchange. The success page renders "Email verified, you can close
+      // this page" — no session, no buttons.
       callbackURL: "/verify-email/success",
       sendVerificationEmail: async ({ url, user }) => {
         if (!mailer) {

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "tsBuildInfoFile": ".tsbuildinfo",
     "module": "ESNext",
-    "moduleResolution": "bundler",
-    "target": "ES2022"
+    "moduleResolution": "bundler"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -22,18 +22,6 @@
   "dependencies": {
     "evlog": "^2.18.1"
   },
-  "peerDependencies": {
-    "better-auth": "^1.6.10",
-    "hono": "^4.12.0",
-    "next": "^16.0.0",
-    "react": "^19.0.0"
-  },
-  "peerDependenciesMeta": {
-    "better-auth": { "optional": true },
-    "hono": { "optional": true },
-    "next": { "optional": true },
-    "react": { "optional": true }
-  },
   "devDependencies": {
     "@repo/config-vitest": "workspace:*",
     "@repo/typescript-config": "workspace:*",
@@ -45,5 +33,25 @@
     "react": "^19.2.6",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
+  },
+  "peerDependencies": {
+    "better-auth": "^1.6.10",
+    "hono": "^4.12.0",
+    "next": "^16.0.0",
+    "react": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "better-auth": {
+      "optional": true
+    },
+    "hono": {
+      "optional": true
+    },
+    "next": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    }
   }
 }

--- a/packages/observability/src/auth.test.ts
+++ b/packages/observability/src/auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createIdentify } from "./auth";
 
 describe("createIdentify", () => {

--- a/packages/observability/src/auth.ts
+++ b/packages/observability/src/auth.ts
@@ -1,5 +1,6 @@
-import { createAuthMiddleware, type BetterAuthInstance } from "evlog/better-auth";
 import "./fields";
+
+import { createAuthMiddleware, type BetterAuthInstance } from "evlog/better-auth";
 
 /**
  * Wraps evlog's Better Auth middleware. Returns identify(log, headers, path?)

--- a/packages/observability/src/config.test.ts
+++ b/packages/observability/src/config.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { buildConfig } from "./config";
 
 describe("buildConfig", () => {

--- a/packages/observability/src/hono.test.ts
+++ b/packages/observability/src/hono.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { honoEvlog, initApiLogger } from "./hono";
 
 describe("hono surface", () => {

--- a/packages/observability/src/hono.ts
+++ b/packages/observability/src/hono.ts
@@ -1,7 +1,9 @@
+import "./fields";
+
 import { initLogger, log } from "evlog";
 import { evlog, type EvlogVariables } from "evlog/hono";
+
 import { buildConfig } from "./config";
-import "./fields";
 
 /** Initialize the global evlog logger for a long-running Hono (Railway) service. */
 const initApiLogger = (opts: { service: string }): void => {

--- a/packages/observability/src/next.ts
+++ b/packages/observability/src/next.ts
@@ -1,7 +1,9 @@
+import "./fields";
+
 import { createEvlog, evlogMiddleware } from "evlog/next";
 import { createInstrumentation } from "evlog/next/instrumentation";
+
 import { buildConfig } from "./config";
-import "./fields";
 
 /** Per-app Next factory. Returns request-scoped helpers + instrumentation hooks. */
 const createObservability = (opts: { service: string }) => {

--- a/packages/observability/src/worker.test.ts
+++ b/packages/observability/src/worker.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { createJobLogger, initWorkerLogger } from "./worker";
 
 describe("worker surface", () => {

--- a/packages/observability/src/worker.ts
+++ b/packages/observability/src/worker.ts
@@ -1,6 +1,8 @@
-import { createLogger, initLogger } from "evlog";
-import { buildConfig } from "./config";
 import "./fields";
+
+import { createLogger, initLogger } from "evlog";
+
+import { buildConfig } from "./config";
 
 /** Initialize the global evlog logger for a long-running BullMQ worker process. */
 const initWorkerLogger = (opts: { service: string }): void => {

--- a/packages/transactional/src/lib/send-email.ts
+++ b/packages/transactional/src/lib/send-email.ts
@@ -10,8 +10,8 @@ import { z } from "zod";
 // in inboxes, so the validator has to accept it.
 const senderAddressSchema = z.string().refine(
   (val) => {
-    const wrapped = val.match(/^.+<([^<>\s]+)>$/v);
-    const email = wrapped ? wrapped[1] : val;
+    const wrapped = val.match(/^.+<(?<address>[^<>\s]+)>$/v);
+    const email = wrapped?.groups?.address ?? val;
     return z.email().safeParse(email).success;
   },
   { message: "Must be a valid email or 'Display Name <email>' format" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,12 @@ importers:
       '@repo/db':
         specifier: workspace:*
         version: link:packages/db
+      better-auth:
+        specifier: ^1.6.10
+        version: 1.6.10(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(mysql2@3.15.3)(next@16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.20.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5)(vue@3.5.34(typescript@6.0.3))
       fallow:
-        specifier: ^2.69.0
-        version: 2.69.0
+        specifier: ^2.85.0
+        version: 2.91.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -24,14 +27,14 @@ importers:
         specifier: ^17.0.4
         version: 17.0.4
       oxfmt:
-        specifier: ^0.48.0
-        version: 0.48.0
+        specifier: ^0.52.0
+        version: 0.52.0
       oxlint:
-        specifier: ^1.63.0
-        version: 1.63.0
+        specifier: ^1.67.0
+        version: 1.69.0
       oxlint-config-awesomeness:
         specifier: ^3.0.2
-        version: 3.0.2(eslint@9.39.2(jiti@2.7.0))(oxlint@1.63.0)(typescript@6.0.3)
+        version: 3.0.2(eslint@9.39.2(jiti@2.7.0))(oxlint@1.69.0)(typescript@6.0.3)
       turbo:
         specifier: ^2.9.12
         version: 2.9.12
@@ -200,6 +203,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@total-typescript/ts-reset':
         specifier: ^0.6.1
         version: 0.6.1
@@ -1220,43 +1226,43 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@fallow-cli/darwin-arm64@2.69.0':
-    resolution: {integrity: sha512-8pp/AY4lNml/N9Bo0xbSzrmvyiiJg6lz5i8G9HCEptrH9W2YyFhQYm0XTbwoy3ATNnjw3aRDajiFTV5njahhSQ==}
+  '@fallow-cli/darwin-arm64@2.91.0':
+    resolution: {integrity: sha512-srKb1BUNgGuWsFpiwtBbgu7holAEA/YtNuv0iWOHmD9bDCH944SomV2ehP7HqO9KE7D6bhFxHXoE9S5tyaPmzw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@fallow-cli/darwin-x64@2.69.0':
-    resolution: {integrity: sha512-nCZwXCJC+MQpwDb0CS4aGHPbaNAnH5//eceotjGc/sSrvXYg3oINAP2ztVDwBAUwwiYwiOGU0W1npVIoQrYgVQ==}
+  '@fallow-cli/darwin-x64@2.91.0':
+    resolution: {integrity: sha512-/6DrBEDtDSAltXi7Bj5UoBG6yhoUCH2gAp/XXZ6Xr2ErLz9X088q6Kw9sfIyhDNpt9mpOQ8K/nsaE7EAjZfeZg==}
     cpu: [x64]
     os: [darwin]
 
-  '@fallow-cli/linux-arm64-gnu@2.69.0':
-    resolution: {integrity: sha512-cfRKQHZMXd8/k8Arr2LlYr2eZDvqx/jZ6K30/8ji/iREXcGYkhfFB4Hk53t7CP8MxbtXGzJ05yyC7n+gf3MOaw==}
+  '@fallow-cli/linux-arm64-gnu@2.91.0':
+    resolution: {integrity: sha512-Qlr7oCxa/IydLGUWMayTWXMvud/Jzzya7ISGAv5kIoXTd4kfqHYXI88wtNEjixIjJz/KiEPgCF7lLtiGeOIcJQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@fallow-cli/linux-arm64-musl@2.69.0':
-    resolution: {integrity: sha512-SgOcAG0VMWJ1eOsMvOdIGYYjebUNsTzNHaOnUch2o8KFvaZkWuoLvfllLC7jI5UMbC4dET/+siOcruKprxPR5w==}
+  '@fallow-cli/linux-arm64-musl@2.91.0':
+    resolution: {integrity: sha512-yl5q62ewqd33NzyS3g9rzetuFDAZ1oOMMcxZgXr0MTjzHymZhqfjNzUxLwAgI49w0sGJ5KXUdTfDRncvhNvpBw==}
     cpu: [arm64]
     os: [linux]
 
-  '@fallow-cli/linux-x64-gnu@2.69.0':
-    resolution: {integrity: sha512-mx9h6Fv7IpoFWJtilKlNFWtANbsxMSDDdHTatYN+VJh9WpsmgMgsoiyxI+K3lheLUe9albgMZjOa3EKlR8ry7w==}
+  '@fallow-cli/linux-x64-gnu@2.91.0':
+    resolution: {integrity: sha512-iklZtyr/OD7stfI4Zj2YhrYRzDDn0rQguLolQtG2T4Is+bfDEBHSglsMSM9/7n2pPAlNAPSOkxeV+VjofzXJkg==}
     cpu: [x64]
     os: [linux]
 
-  '@fallow-cli/linux-x64-musl@2.69.0':
-    resolution: {integrity: sha512-H5oS1lge94bp6GoxCgJgi+wT36zD9nDW7rTxBfEG6gqXKpALYs3uIF4lbzzELNC8GZwGe4YQhMxxqGm5CXfCrg==}
+  '@fallow-cli/linux-x64-musl@2.91.0':
+    resolution: {integrity: sha512-pFLIQ0J6C3Rk234aK4enfoirPnifeoJ7n0Eti+69CLl/Y0ZU5wqesQY6LkonJl8Cgt+j1y1eA3Ld3ilb8//9CA==}
     cpu: [x64]
     os: [linux]
 
-  '@fallow-cli/win32-arm64-msvc@2.69.0':
-    resolution: {integrity: sha512-NEl4EnKzXw/lwrboUiAxWHrVx4tBO+cpNuPmvJoRsLS8wG5UIOxbyjHjD9Ux2FbwXNaRzZZ+vjLJAvGdOEU0Xw==}
+  '@fallow-cli/win32-arm64-msvc@2.91.0':
+    resolution: {integrity: sha512-8FHsFrD1np1Fq1+jI+c3aTtlkGwMqPsfPUqfjeXopQGBDGM+XQX970/3WaPoCVx7pGAHQrMvYDRt7rSra+knvw==}
     cpu: [arm64]
     os: [win32]
 
-  '@fallow-cli/win32-x64-msvc@2.69.0':
-    resolution: {integrity: sha512-EeL+Bbdg9XOgMl7tG0k6DCKhCaXLS0EPiy3HWccKUaMYDgR+haUWDzAGa9nJqIBlR4GYz/lz6amSCJtV+XsMzA==}
+  '@fallow-cli/win32-x64-msvc@2.91.0':
+    resolution: {integrity: sha512-0ebx+vkEuTit3MIy/3b1xezsyp+xz67fR49Mq6tBqlPAXRXgVYc9rAsSSzHpqFFIU9U8cpqbSKFpJskRscluCg==}
     cpu: [x64]
     os: [win32]
 
@@ -1744,246 +1750,246 @@ packages:
   '@oxc-project/types@0.129.0':
     resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
 
-  '@oxfmt/binding-android-arm-eabi@0.48.0':
-    resolution: {integrity: sha512-uwqk+/KhQvBIpULD8SMM/zAafMRC/+DV/xsEQjkkIsJ/kLmEI/2bxonVowcYTiXqqZ/a0FEW8DPkZY3VvwELDA==}
+  '@oxfmt/binding-android-arm-eabi@0.52.0':
+    resolution: {integrity: sha512-17EMSJnQ9g+upVHrAUYDMfH5lvRKQ9Nvg8WtEoH72oDr1VpWz+7/o3tD97U1EToen2YAQ/68JmtDYkQUi20dfQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.48.0':
-    resolution: {integrity: sha512-VUCiKuXK5+McVssgHEJdrcGK7hRJzrRb36zm9/jwzMholyYt4BgXhw5Nm1V1DX6Ce717Zi/1jk432b/tgmQgtQ==}
+  '@oxfmt/binding-android-arm64@0.52.0':
+    resolution: {integrity: sha512-A2G1IdwGEW2lLJkIxcvuirRH1CzSl/e0NX11zTlW1gvxJThfwbI/BEoaKrTNpm7M2FchvIf6guvIQU7d5iz+OQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-darwin-arm64@0.48.0':
-    resolution: {integrity: sha512-IkKp8rnIyQLW6Jt+6jragCbUVYSayk55lapiprLjIVvt4NczLyO/nwX2GgefLQ5iaBdfS8UEAFgCs/pLO6Cl0w==}
+  '@oxfmt/binding-darwin-arm64@0.52.0':
+    resolution: {integrity: sha512-f9+bLvOYxy7NttCLFTvQ7afmqDOWY4wIP9xdvfj5trQ1qj6f2UFAGwZESlfsMjvJNTyRpXfIlOanCI9FOvoeQA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.48.0':
-    resolution: {integrity: sha512-+aFuhsGIuvnoOjXyKVHMhPKJZR1kQkAl8QyrKoMlA7yJsSTC3N0Asl53La8TChSHhW8epToQ/Q0nvLmEmfNmLg==}
+  '@oxfmt/binding-darwin-x64@0.52.0':
+    resolution: {integrity: sha512-YSTB9sJ5nnQd/Q0ddHkgof0ZCHPAnWZT1IW2SJ8omz7CP7KluJhO1fNHrpqdxCtpztJwSs4hY1uAee35wKxxaw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-freebsd-x64@0.48.0':
-    resolution: {integrity: sha512-fbqzQL8FjI9gGnktI7RIo0dksDziTAYBy7xlI7jU7eID5fxLF/25fS4Xj6GydD8Y5oWHL83U4NK160QaOAxtyg==}
+  '@oxfmt/binding-freebsd-x64@0.52.0':
+    resolution: {integrity: sha512-NIrRNTTPCs4UbmVs0bxLSCDlLCtIRMJIXklNKaXa5Oj2/K1UIMBvgE8+uPVo01Io3N9HF0+GAX+aAHjUgZS7vA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.48.0':
-    resolution: {integrity: sha512-hn4i0zhAyTiB3ZHjQfYUZkDvrbVkohw1S7pySWxWUoZ87HnkDoTFThj7QTxk40hNPOTUP0vHbPRNamFIv1HBJQ==}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.52.0':
+    resolution: {integrity: sha512-JXUCde8mn3GpgQouz2PXUokgy/uT1QrRJBL2s983VWcSQp62wTFYiNXgTKdeo1Jgbr0IgUnKKvzIk/YBlj/nVQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.48.0':
-    resolution: {integrity: sha512-R4WBD9qF3QM9hqgdAa+fBGXmquTvDUujrPQ36t2Sjk8RPOSKGHDeN7l/khr10hqbQaOq9KCgPHG9ubNET/X/RQ==}
+  '@oxfmt/binding-linux-arm-musleabihf@0.52.0':
+    resolution: {integrity: sha512-psbUXaRZ+V8DaXz10Qf7LSHtdtdKAmC8fxXgeU608jjzrmWK4quamZMOpl6sf+dikoFHA85uE93Q0BqxrCdQrQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.48.0':
-    resolution: {integrity: sha512-5bVdwSwlm1M8wbYCorLOxWxUBw/8tBvHYyQNIfwWVPwOJaj5vg1APSGJQVpwJfV5VNE9PSrR91UKEpoNwHhqUA==}
+  '@oxfmt/binding-linux-arm64-gnu@0.52.0':
+    resolution: {integrity: sha512-Jw7MgWUU9lcLCcy82updISP3EthTlfvAwR6gWNxPzqly7+fLvOi2gHQE9xXQjpqaVLm/8P+gOzlv9ODuoVlaaw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-arm64-musl@0.48.0':
-    resolution: {integrity: sha512-vCS3Fk7gFslTqE1lUE2IlroyVV7u/9SmMA/uBqDoshuck2psGWcjW0ePyPZI3rM3+qtf2pDaMVIKMHozraifuw==}
+  '@oxfmt/binding-linux-arm64-musl@0.52.0':
+    resolution: {integrity: sha512-wZg6bLjDvh2KibyI3QFUYo8GTXneIFsd0JvehtvJiUmQ8WRPERgxd/VM4ctWb86U5FT1FkqgS8/wZKVB+AZScg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.48.0':
-    resolution: {integrity: sha512-gKtfFfueUClXDumyoHUbymqRf7prHejOOyzJK0eIJn93GF9JBdFHdo60TM1ZBHxkEwZvjuOgHmKtneKbEOc/Eg==}
+  '@oxfmt/binding-linux-ppc64-gnu@0.52.0':
+    resolution: {integrity: sha512-IngE8uxhNvxcMrLjZNDo9xNLY7rEK33AKnaMd2B46he1e/mz2CfcW6If/U1wUjdRZddm1QzQaciqZkuMkdh1FA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.48.0':
-    resolution: {integrity: sha512-SYt0UhOvZD/UwZz9sXq6J2uAw8o24f5VZpLB2DH01f6MevshmlgakQlZe2lwek2sZJkd07eLu7mZa0g7yeiw7Q==}
+  '@oxfmt/binding-linux-riscv64-gnu@0.52.0':
+    resolution: {integrity: sha512-H3+DdFMv/efN3Efmhsv18jDrpiWWqKG7wsfAlQBqAt6z/E2Bx+TwEj2Nowe51CPOWB8/mFBC2dAMSgVFLvvowA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.48.0':
-    resolution: {integrity: sha512-JLbrwck2AopG4ud/XklZO5N+qxGC7cS7ROvXZVNfx0MCLDDL2kGOLvzuWORkVjnjAM0CMAfIMU2zNBtQbM+4dw==}
+  '@oxfmt/binding-linux-riscv64-musl@0.52.0':
+    resolution: {integrity: sha512-zji+1kb7lJKohSDjzC1IsS+K/cKRs1hdVf0ZH0VbdbiakmtLvN9twBoXo/k8VdjFax7kfo+DyPxS7vv52br1aw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.48.0':
-    resolution: {integrity: sha512-mdxt5L8OQLxkQH+JVpdC/lknZNe0lX4hlO3d8+xvw2wToo+iDrid9tiGOd5bmHfUVd5wVhrUry0qlu5vq66NkQ==}
+  '@oxfmt/binding-linux-s390x-gnu@0.52.0':
+    resolution: {integrity: sha512-hcLBYedpCy7ToUvvBidWk7+11Yhg1oAZ4+6hKPic/mQI6NaqXJSXMps5nFlwUuX2ewhtLZZDPg63TI042qGKBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-gnu@0.48.0':
-    resolution: {integrity: sha512-oEz1BQwMrV7OMEFx/3VPDU3n9TM0AnxpktDYXjEg5i6nTX87wo18wSfBvkl4tzAICdKtoAQAdBIl7Y7hsPlx5w==}
+  '@oxfmt/binding-linux-x64-gnu@0.52.0':
+    resolution: {integrity: sha512-IDO2loXK2OtTOhSPchU9MW25mWL2QCDGdJbjN8MXKZVS80qXe5gMTwQWu/gMJ3juoBHbkuUZNB2N1LHzNT7DoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-musl@0.48.0':
-    resolution: {integrity: sha512-g2SKTTurP5mWjd8Ecait0erYqmltL4IqW1EwttM25BxM6NiTt4ubobJYMR1uox1V2QgG4UfHH10CGRvWlUixjw==}
+  '@oxfmt/binding-linux-x64-musl@0.52.0':
+    resolution: {integrity: sha512-mAV2Hjn0SatJ+KoAzKUC3eJhdJ8wv+3m1KyuS0dTsbF0c5weq+QrCt/DRZZM+uj/XiKzCDEUKYsBF30e2qkcyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-openharmony-arm64@0.48.0':
-    resolution: {integrity: sha512-CIg24VgheEpvolHL2gQuax5qcQ602bRMHrJ9g8XsQr3iVj9aSPgopigBKuMqrXsupwkrU+RQCn5cG8PgFntR6w==}
+  '@oxfmt/binding-openharmony-arm64@0.52.0':
+    resolution: {integrity: sha512-vd4npaUIwChxp7XzkqmepBWTT9YMcSe/NBApVGPC30/lLyOVaV3dvma1SKo03t8O73BPRAG7EyJzGlN5cJM5hQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.48.0':
-    resolution: {integrity: sha512-zeaWkcxcEULwkGF3I/HgEvcDPN8buYDrxibBUa/IFh5Vmwyge+KpLO+hEwSovW349H0O/C0Z2kaFmEzEDm00/Q==}
+  '@oxfmt/binding-win32-arm64-msvc@0.52.0':
+    resolution: {integrity: sha512-k2sz6gWQdMfh5HPpIS+Bw/0UEV/kaK2xuqJRrWL233sEHx9WLlsmvlPFM4HUNThkYbSN0U0vPW7LVKZWDS8hPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.48.0':
-    resolution: {integrity: sha512-yiEKnIAGvx5CyZQOlMaNlZkAbwT7/Quk0j3WLt+PR5hK+qYjPTRRJYDfD77wCBPLvEYAG41v4KG3iL0H+uxoxg==}
+  '@oxfmt/binding-win32-ia32-msvc@0.52.0':
+    resolution: {integrity: sha512-rhke69GTcArodLHpjMTfNnvjTEBryDeZcUCKK/VjXDMtfTULl6QRh0ymX5/hbCUv2WjYm9h/QbW++q2vE15gWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.48.0':
-    resolution: {integrity: sha512-GSD2+7t2UoVMV2NgxXypa4bKewflPMAjYnF0Xw9/ht82ZfafAHhb8STwrEd7wlH2PFogt5zw3WVCxYJaHUdbeQ==}
+  '@oxfmt/binding-win32-x64-msvc@0.52.0':
+    resolution: {integrity: sha512-q5xL7oeXkZdEtNZWBdvehJcmt+GRu9l2bK40yJs1jJXlqq+r0Hygb1rTjq+FM2o/2xyt4cufH6KRplHp3Jjsvw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.63.0':
-    resolution: {integrity: sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg==}
+  '@oxlint/binding-android-arm-eabi@1.69.0':
+    resolution: {integrity: sha512-DKQQbD5cZ/MYfDgDI7YGyGD9FSxABlsBsYFo5p26lloob543tP9+4N3guwdXIYJN+7HSZxLe8YJuwcOWw5qnHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.63.0':
-    resolution: {integrity: sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A==}
+  '@oxlint/binding-android-arm64@1.69.0':
+    resolution: {integrity: sha512-lEhb+I5pr4inux+JFwfCa1HRq3Os7NirEFQ0H1I35SVEHPm6byX0Ah47xmRha3qi6LAkxUcxViL8o/9PivjzBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.63.0':
-    resolution: {integrity: sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g==}
+  '@oxlint/binding-darwin-arm64@1.69.0':
+    resolution: {integrity: sha512-GY2YE8lOZW59BW1Ia1y+1gR0XyjrZRvVWHAr8LGeGhYHE0OQJ/7cRKXTkx1P+E9/6awEc3SX8a68SFTjh/E//A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.63.0':
-    resolution: {integrity: sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw==}
+  '@oxlint/binding-darwin-x64@1.69.0':
+    resolution: {integrity: sha512-ax1oZnOjHX3LB7myQyHEaQkDwfLb6str3/nSP6O7EVUviQGNkEGzGV0EqcBJWK+Ufwx0l4xPgyYayurvhAdl2Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.63.0':
-    resolution: {integrity: sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA==}
+  '@oxlint/binding-freebsd-x64@1.69.0':
+    resolution: {integrity: sha512-kHWeHv4g2h8NY+mpCxzCtY4uerMJWTN/TSnNj1CPbakFpHEJ6cTya2wWV0pDSYWOJ2+0UiEbhn3AtXxHtsnKjg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.63.0':
-    resolution: {integrity: sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.69.0':
+    resolution: {integrity: sha512-gq84vM1a1oEehXo27YCDzGVcxPsZDI1yswZwz2Da1/cbnWtrL16XZZnz0G/+gIU8edtHpfjxq5c+vWEHqJfWoQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.63.0':
-    resolution: {integrity: sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg==}
+  '@oxlint/binding-linux-arm-musleabihf@1.69.0':
+    resolution: {integrity: sha512-kIqEa98JQ0VRyrcncxA417m2AzasqTlD+FyVT1AksjvjkqQcvm7pBWYvoW3/mpyOP2XYvi5nSCCTIe6De1yu5g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.63.0':
-    resolution: {integrity: sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ==}
+  '@oxlint/binding-linux-arm64-gnu@1.69.0':
+    resolution: {integrity: sha512-j+xYiXozxGWx2cpjCrwwGR4awTxPFsRv3JZrv23RCogEPMc4R7UqjHW47p/RG0aRlbWiROCJ8coUfCwy0dvzHA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-arm64-musl@1.63.0':
-    resolution: {integrity: sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g==}
+  '@oxlint/binding-linux-arm64-musl@1.69.0':
+    resolution: {integrity: sha512-xEPpNppTfN1l/nM7gYSf9iocscu/as+p/7vxkLeLEKnYU+09Dm+5V6IhDYDh+Uz6FajEupWwCLt5SOG0y1PCKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.63.0':
-    resolution: {integrity: sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ==}
+  '@oxlint/binding-linux-ppc64-gnu@1.69.0':
+    resolution: {integrity: sha512-Ug0+eU7HJBlek+SjklYH62IlOMirEJsdxpihH0kSqX0XdrDD4NdHpQc10fK1JC35yn6KrrcN+uYzlHD38XAf8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.63.0':
-    resolution: {integrity: sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA==}
+  '@oxlint/binding-linux-riscv64-gnu@1.69.0':
+    resolution: {integrity: sha512-iEyI3GIg0l/s3G4qy2TlaaWKdzj4PJJStwtlocpDTC00PY9hZueotf6OKUj9+yfQh0lrpBW/pLMgTztbAHKJEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.63.0':
-    resolution: {integrity: sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ==}
+  '@oxlint/binding-linux-riscv64-musl@1.69.0':
+    resolution: {integrity: sha512-NjHjpiI4WIKSMwuoJSZi5VToPeoYOS1FR52HLIDG6lidMdqquusgtODb4iLk0+lb1q3Z0nv2/aPRcC/olmpQGg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.63.0':
-    resolution: {integrity: sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg==}
+  '@oxlint/binding-linux-s390x-gnu@1.69.0':
+    resolution: {integrity: sha512-Ai/prDewoItkDXbp38gwGZi41DycZbUTZJ3UidwoHgQC0/DaqC2TGdtBTQLJ6hSD+SAxASzh8+/eSBPmxfOacA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-gnu@1.63.0':
-    resolution: {integrity: sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA==}
+  '@oxlint/binding-linux-x64-gnu@1.69.0':
+    resolution: {integrity: sha512-Gt3KHgp46mRKz4sJeaASmKvD8ayXookRw07RMf+NowhEztGGDZ7VrXpoW96XuKJLjFukWizOFVNjmYb/u7caNQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.63.0':
-    resolution: {integrity: sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A==}
+  '@oxlint/binding-linux-x64-musl@1.69.0':
+    resolution: {integrity: sha512-7tQhJ2+p/oHv1zcfnjYI7YVzC/7iBaVOfIvFYtxdJ5F45mWgEdrCyXZXZGfiLey5t/5JhOhsaMnnv1kAzckd7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.63.0':
-    resolution: {integrity: sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w==}
+  '@oxlint/binding-openharmony-arm64@1.69.0':
+    resolution: {integrity: sha512-vmWz6TKp/3hfA4lksR0zHBv/6xuX1jhym6eqOjdH2DXsDDHZWcp2f0KG0VCAnlVbIrjk29G4wAWMXb/Hn1YobA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.63.0':
-    resolution: {integrity: sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg==}
+  '@oxlint/binding-win32-arm64-msvc@1.69.0':
+    resolution: {integrity: sha512-9RExaLgmaw6IoIkU9cTpT71mLfI0xZ86iZH8x518LVsOkjquJMYqb9P7KpC8lgd1t0Dxs41p2pxynq4XR3Ttzw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.63.0':
-    resolution: {integrity: sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w==}
+  '@oxlint/binding-win32-ia32-msvc@1.69.0':
+    resolution: {integrity: sha512-1907kRPF8/PrcIw1E7LMs9JbVrpgnt/MvFdss3an8oDkYNAACXzTntV3t3869ZZhMZxb2AzRGbz1pA/jdFatXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.63.0':
-    resolution: {integrity: sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA==}
+  '@oxlint/binding-win32-x64-msvc@1.69.0':
+    resolution: {integrity: sha512-w8SOXv3mT9Fi6jY8OXdXCfnvX/3KNLXGNr4HEz2TA7S4Mv/PYAOmpB8y/ge40mxvBMgGNaSaaDwZpAsQn7HtWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -3756,8 +3762,8 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
-  fallow@2.69.0:
-    resolution: {integrity: sha512-N3vPCjKSJ6mM919xoOtbImoksCgtTllC/y2xOe3aQfffK5AVJNvP4STgZ69xnqcMTfSB6CYQBFbHPnKgfOgrVg==}
+  fallow@2.91.0:
+    resolution: {integrity: sha512-DHf+w30Z6Kt1JRg83rl27TaNJHTs09W7Egtal7CxIkz8pSMZNpryLpvIzh+41MMrPzJRA1q8r81umdNdZFoxzw==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -4873,10 +4879,18 @@ packages:
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
-  oxfmt@0.48.0:
-    resolution: {integrity: sha512-AVaLh+7XeGx+R1zfFV+f6VV61nT2MWVJXVUDhbTm5LBWGyNt64xAyh3NYYyjeY2WykNt9AvqSQLPHcbWquYF9g==}
+  oxfmt@0.52.0:
+    resolution: {integrity: sha512-nJlYM35F64zTDMecCNhoHNkf+D/eHv7xcjj9XDSj+bFAVtN93m7v8DQMdHd6nDG6Akf/kEYYHmDUBs2Dz27Sug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
 
   oxlint-config-awesomeness@3.0.2:
     resolution: {integrity: sha512-tFDsaBY+0SGxlzWD7bwmKaUulAuNIevv/kp1bK+CMER1o7z+/zpPcaEJnr/Dhb50ty8qyAxlh7hW/AGLRR4tEg==}
@@ -4884,14 +4898,17 @@ packages:
     peerDependencies:
       oxlint: '>=1.63.0 <2.0.0'
 
-  oxlint@1.63.0:
-    resolution: {integrity: sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg==}
+  oxlint@1.69.0:
+    resolution: {integrity: sha512-ypZkK/aDc5NQV8zIR6s2H2Tl3aNW8FmJ1m9+2qsaYuRenl8vgnHNCGwTHviWJdUQzglOlHFchgopdtGhSy17Rw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       oxlint-tsgolint: '>=0.22.1'
+      vite-plus: '*'
     peerDependenciesMeta:
       oxlint-tsgolint:
+        optional: true
+      vite-plus:
         optional: true
 
   p-event@6.0.1:
@@ -6394,7 +6411,7 @@ snapshots:
 
   '@base-ui/utils@0.2.8(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@floating-ui/utils': 0.2.11
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -6736,28 +6753,28 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.2.0
 
-  '@fallow-cli/darwin-arm64@2.69.0':
+  '@fallow-cli/darwin-arm64@2.91.0':
     optional: true
 
-  '@fallow-cli/darwin-x64@2.69.0':
+  '@fallow-cli/darwin-x64@2.91.0':
     optional: true
 
-  '@fallow-cli/linux-arm64-gnu@2.69.0':
+  '@fallow-cli/linux-arm64-gnu@2.91.0':
     optional: true
 
-  '@fallow-cli/linux-arm64-musl@2.69.0':
+  '@fallow-cli/linux-arm64-musl@2.91.0':
     optional: true
 
-  '@fallow-cli/linux-x64-gnu@2.69.0':
+  '@fallow-cli/linux-x64-gnu@2.91.0':
     optional: true
 
-  '@fallow-cli/linux-x64-musl@2.69.0':
+  '@fallow-cli/linux-x64-musl@2.91.0':
     optional: true
 
-  '@fallow-cli/win32-arm64-msvc@2.69.0':
+  '@fallow-cli/win32-arm64-msvc@2.91.0':
     optional: true
 
-  '@fallow-cli/win32-x64-msvc@2.69.0':
+  '@fallow-cli/win32-x64-msvc@2.91.0':
     optional: true
 
   '@floating-ui/core@1.7.5':
@@ -7127,118 +7144,118 @@ snapshots:
 
   '@oxc-project/types@0.129.0': {}
 
-  '@oxfmt/binding-android-arm-eabi@0.48.0':
+  '@oxfmt/binding-android-arm-eabi@0.52.0':
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.48.0':
+  '@oxfmt/binding-android-arm64@0.52.0':
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.48.0':
+  '@oxfmt/binding-darwin-arm64@0.52.0':
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.48.0':
+  '@oxfmt/binding-darwin-x64@0.52.0':
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.48.0':
+  '@oxfmt/binding-freebsd-x64@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.48.0':
+  '@oxfmt/binding-linux-arm-gnueabihf@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.48.0':
+  '@oxfmt/binding-linux-arm-musleabihf@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.48.0':
+  '@oxfmt/binding-linux-arm64-gnu@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.48.0':
+  '@oxfmt/binding-linux-arm64-musl@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.48.0':
+  '@oxfmt/binding-linux-ppc64-gnu@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.48.0':
+  '@oxfmt/binding-linux-riscv64-gnu@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.48.0':
+  '@oxfmt/binding-linux-riscv64-musl@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.48.0':
+  '@oxfmt/binding-linux-s390x-gnu@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.48.0':
+  '@oxfmt/binding-linux-x64-gnu@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.48.0':
+  '@oxfmt/binding-linux-x64-musl@0.52.0':
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.48.0':
+  '@oxfmt/binding-openharmony-arm64@0.52.0':
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.48.0':
+  '@oxfmt/binding-win32-arm64-msvc@0.52.0':
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.48.0':
+  '@oxfmt/binding-win32-ia32-msvc@0.52.0':
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.48.0':
+  '@oxfmt/binding-win32-x64-msvc@0.52.0':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.63.0':
+  '@oxlint/binding-android-arm-eabi@1.69.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.63.0':
+  '@oxlint/binding-android-arm64@1.69.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.63.0':
+  '@oxlint/binding-darwin-arm64@1.69.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.63.0':
+  '@oxlint/binding-darwin-x64@1.69.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.63.0':
+  '@oxlint/binding-freebsd-x64@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.63.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.63.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.63.0':
+  '@oxlint/binding-linux-arm64-gnu@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.63.0':
+  '@oxlint/binding-linux-arm64-musl@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.63.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.63.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.63.0':
+  '@oxlint/binding-linux-riscv64-musl@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.63.0':
+  '@oxlint/binding-linux-s390x-gnu@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.63.0':
+  '@oxlint/binding-linux-x64-gnu@1.69.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.63.0':
+  '@oxlint/binding-linux-x64-musl@1.69.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.63.0':
+  '@oxlint/binding-openharmony-arm64@1.69.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.63.0':
+  '@oxlint/binding-win32-arm64-msvc@1.69.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.63.0':
+  '@oxlint/binding-win32-ia32-msvc@1.69.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.63.0':
+  '@oxlint/binding-win32-x64-msvc@1.69.0':
     optional: true
 
   '@phosphor-icons/core@2.1.1': {}
@@ -7832,7 +7849,7 @@ snapshots:
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -8969,18 +8986,18 @@ snapshots:
 
   extend@3.0.2: {}
 
-  fallow@2.69.0:
+  fallow@2.91.0:
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      '@fallow-cli/darwin-arm64': 2.69.0
-      '@fallow-cli/darwin-x64': 2.69.0
-      '@fallow-cli/linux-arm64-gnu': 2.69.0
-      '@fallow-cli/linux-arm64-musl': 2.69.0
-      '@fallow-cli/linux-x64-gnu': 2.69.0
-      '@fallow-cli/linux-x64-musl': 2.69.0
-      '@fallow-cli/win32-arm64-msvc': 2.69.0
-      '@fallow-cli/win32-x64-msvc': 2.69.0
+      '@fallow-cli/darwin-arm64': 2.91.0
+      '@fallow-cli/darwin-x64': 2.91.0
+      '@fallow-cli/linux-arm64-gnu': 2.91.0
+      '@fallow-cli/linux-arm64-musl': 2.91.0
+      '@fallow-cli/linux-x64-gnu': 2.91.0
+      '@fallow-cli/linux-x64-musl': 2.91.0
+      '@fallow-cli/win32-arm64-msvc': 2.91.0
+      '@fallow-cli/win32-x64-msvc': 2.91.0
 
   fast-check@3.23.2:
     dependencies:
@@ -10295,64 +10312,64 @@ snapshots:
 
   outvariant@1.4.3: {}
 
-  oxfmt@0.48.0:
+  oxfmt@0.52.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.48.0
-      '@oxfmt/binding-android-arm64': 0.48.0
-      '@oxfmt/binding-darwin-arm64': 0.48.0
-      '@oxfmt/binding-darwin-x64': 0.48.0
-      '@oxfmt/binding-freebsd-x64': 0.48.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.48.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.48.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.48.0
-      '@oxfmt/binding-linux-arm64-musl': 0.48.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.48.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.48.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.48.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.48.0
-      '@oxfmt/binding-linux-x64-gnu': 0.48.0
-      '@oxfmt/binding-linux-x64-musl': 0.48.0
-      '@oxfmt/binding-openharmony-arm64': 0.48.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.48.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.48.0
-      '@oxfmt/binding-win32-x64-msvc': 0.48.0
+      '@oxfmt/binding-android-arm-eabi': 0.52.0
+      '@oxfmt/binding-android-arm64': 0.52.0
+      '@oxfmt/binding-darwin-arm64': 0.52.0
+      '@oxfmt/binding-darwin-x64': 0.52.0
+      '@oxfmt/binding-freebsd-x64': 0.52.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.52.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.52.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.52.0
+      '@oxfmt/binding-linux-arm64-musl': 0.52.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.52.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.52.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.52.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.52.0
+      '@oxfmt/binding-linux-x64-gnu': 0.52.0
+      '@oxfmt/binding-linux-x64-musl': 0.52.0
+      '@oxfmt/binding-openharmony-arm64': 0.52.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.52.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.52.0
+      '@oxfmt/binding-win32-x64-msvc': 0.52.0
 
-  oxlint-config-awesomeness@3.0.2(eslint@9.39.2(jiti@2.7.0))(oxlint@1.63.0)(typescript@6.0.3):
+  oxlint-config-awesomeness@3.0.2(eslint@9.39.2(jiti@2.7.0))(oxlint@1.69.0)(typescript@6.0.3):
     dependencies:
       eslint-plugin-no-only-tests: 3.4.0
       eslint-plugin-perfectionist: 5.9.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-unused-imports: 4.4.1(eslint@9.39.2(jiti@2.7.0))
-      oxlint: 1.63.0
+      oxlint: 1.69.0
     transitivePeerDependencies:
       - '@typescript-eslint/eslint-plugin'
       - eslint
       - supports-color
       - typescript
 
-  oxlint@1.63.0:
+  oxlint@1.69.0:
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.63.0
-      '@oxlint/binding-android-arm64': 1.63.0
-      '@oxlint/binding-darwin-arm64': 1.63.0
-      '@oxlint/binding-darwin-x64': 1.63.0
-      '@oxlint/binding-freebsd-x64': 1.63.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.63.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.63.0
-      '@oxlint/binding-linux-arm64-gnu': 1.63.0
-      '@oxlint/binding-linux-arm64-musl': 1.63.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.63.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.63.0
-      '@oxlint/binding-linux-riscv64-musl': 1.63.0
-      '@oxlint/binding-linux-s390x-gnu': 1.63.0
-      '@oxlint/binding-linux-x64-gnu': 1.63.0
-      '@oxlint/binding-linux-x64-musl': 1.63.0
-      '@oxlint/binding-openharmony-arm64': 1.63.0
-      '@oxlint/binding-win32-arm64-msvc': 1.63.0
-      '@oxlint/binding-win32-ia32-msvc': 1.63.0
-      '@oxlint/binding-win32-x64-msvc': 1.63.0
+      '@oxlint/binding-android-arm-eabi': 1.69.0
+      '@oxlint/binding-android-arm64': 1.69.0
+      '@oxlint/binding-darwin-arm64': 1.69.0
+      '@oxlint/binding-darwin-x64': 1.69.0
+      '@oxlint/binding-freebsd-x64': 1.69.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.69.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.69.0
+      '@oxlint/binding-linux-arm64-gnu': 1.69.0
+      '@oxlint/binding-linux-arm64-musl': 1.69.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.69.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.69.0
+      '@oxlint/binding-linux-riscv64-musl': 1.69.0
+      '@oxlint/binding-linux-s390x-gnu': 1.69.0
+      '@oxlint/binding-linux-x64-gnu': 1.69.0
+      '@oxlint/binding-linux-x64-musl': 1.69.0
+      '@oxlint/binding-openharmony-arm64': 1.69.0
+      '@oxlint/binding-win32-arm64-msvc': 1.69.0
+      '@oxlint/binding-win32-ia32-msvc': 1.69.0
+      '@oxlint/binding-win32-x64-msvc': 1.69.0
 
   p-event@6.0.1:
     dependencies:

--- a/tests/e2e/auth-email/change-email.spec.ts
+++ b/tests/e2e/auth-email/change-email.spec.ts
@@ -31,9 +31,9 @@ test.describe("Change email (two-stage confirmation + verification)", () => {
     expect([200, 201]).toContain(signUp.status());
     const verify = await verification.forVerifyEmail(currentEmail);
     await page.goto(verify.url);
-    // autoSignInAfterVerification: true sets a session cookie on the clicker
-    // page, but the test then drives the rest of the flow via the
-    // APIRequestContext, which doesn't share cookies — so sign in separately.
+    // autoSignInAfterVerification: false means the verify click lands on
+    // /verify-email/success without setting a session cookie — so sign in
+    // explicitly to attach the session for the change-email request below.
     await page.waitForURL(/\/verify-email\/success$/v);
     const signIn = await request.post(`${webUrl}/api/auth/sign-in/email`, {
       data: { email: currentEmail, password },

--- a/tests/e2e/auth-email/sign-up-verification.spec.ts
+++ b/tests/e2e/auth-email/sign-up-verification.spec.ts
@@ -45,8 +45,10 @@ test.describe("Sign-up email verification", () => {
     });
     expect(mail.last_event).not.toBe("bounced");
 
-    // Follow the link in a fresh context. autoSignInAfterVerification: true,
-    // so the clicker tab/device gets a session cookie on the verification click.
+    // Follow the link in a fresh BrowserContext (cross-device click). With
+    // autoSignInAfterVerification: false, this lands on the success page
+    // WITHOUT creating a session in the clicker context — the polling tab
+    // elsewhere is the one that completes sign-in.
     const verifyUrl = extractLink(mail, /\/api\/auth\/verify-email\?token=/v);
     const clickerContext = await browser.newContext();
     const clickerPage = await clickerContext.newPage();
@@ -54,11 +56,11 @@ test.describe("Sign-up email verification", () => {
     await expect(clickerPage).toHaveURL(/\/verify-email\/success$/v);
     await expect(clickerPage.getByRole("heading", { name: "Email verified" })).toBeVisible();
     const clickerCookies = await clickerContext.cookies(webUrl);
-    expect(clickerCookies.find((c) => c.name.startsWith("acme."))).toBeDefined();
+    expect(clickerCookies.find((c) => c.name.startsWith("acme."))).toBeUndefined();
     await clickerContext.close();
 
-    // Independent sign-in (different device/context) also succeeds now that
-    // the email is verified — the original signup tab can hit /login normally.
+    // Original-tab path: signIn now succeeds. The pending screen polls this
+    // continuously; the test just exercises the same code path once.
     const postSignIn = await request.post(`${webUrl}/api/auth/sign-in/email`, {
       data: { email, password },
     });

--- a/tests/e2e/helpers/resend.ts
+++ b/tests/e2e/helpers/resend.ts
@@ -174,7 +174,7 @@ const waitForEmail = async (
 const extractLink = (email: ResendEmail, pattern: RegExp): string => {
   const haystack = email.html ?? email.text ?? "";
   // Match an href="..." attribute whose URL satisfies the pattern.
-  const hrefMatches = haystack.matchAll(/href="([^"]+)"/gv);
+  const hrefMatches = haystack.matchAll(/href="(?<href>[^"]+)"/gv);
   for (const [, href] of hrefMatches) {
     const decoded = href.replaceAll("&amp;", "&");
     if (pattern.test(decoded)) {


### PR DESCRIPTION
## Changes

### CI workflows
- Added the 4 missing workflows (`test.yml`, `lint.yml`, `format.yml`, `fallow.yml`) from the canonical acme-package set (already `@v6`, no FORCE escape hatch).
- `e2e.yml`: `actions/checkout@v5`→`@v6`, `pnpm/action-setup@v4`→`@v6`, `actions/setup-node@v5`→`@v6`; dropped `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` (env block kept — it carries the e2e vars). Triggers, permissions, node-version 24, frozen-lockfile unchanged.

### Tooling bump (oxfmt ^0.52.0, oxlint ^1.67.0, fallow ^2.85.0)
New versions surfaced findings, all fixed for real (no downgrades, no broad rule disables):
- **oxlint** `prefer-named-capture-group`: named the groups in `packages/transactional/src/lib/send-email.ts` and `tests/e2e/helpers/resend.ts`.
- **oxlint** `node/callback-return` on Hono `await next()` tail calls: switched to `return next()` (`return await next()` in `requestSizeLimit` to keep `require-await` happy) in `apps/api/src/middleware/{auth,security}.ts`.
- **oxfmt 0.52**: reformatted 10 files (import-group sorting, long-call wrapping, package.json key ordering).
- **fallow 2.85**: removed dead `isPrismaKnownError` export (internal-only); declared `@testing-library/react` in `apps/web` and `better-auth` at root (genuinely imported, previously hoist-resolved); added `.fallowrc` entries for the CI-invoked `ensure-e2e-user.ts` and the reflectively-loaded `apps/*/src/lib/observability.ts`; ignored `better-auth`/`hono` optional-peer devDeps in `@repo/observability` — all mirroring collabtime's already-aligned config.

### typecheck now covers @repo/auth
- Renamed `packages/auth` script `type-check` → `typecheck` so `turbo run typecheck` includes it.
- That surfaced a real error: `send-email.ts` uses a `/v` regex flag, rejected by **`packages/auth/tsconfig.json`'s own `target: "ES2022"` override** (auth typechecks `@repo/transactional` sources via workspace imports, under auth's tsconfig). The override was scaffold leftover — base.json and the rest of the fleet target ESNext (easeia pins ES2024, which also accepts `/v`), and the `module`/`moduleResolution` lines beside it just restate base values. Dropped the `target` override; the `/v` regex stays.

### verify-email credentials-store (ported from collabtime)
- Added `credentials-store.ts` (+ its unit test): in-memory one-shot `{email, password}` handoff between signup and the pending screen.
- `pending-screen.tsx` now takes a token, consumes the stash, and polls `signIn.email` until the verification link is clicked (auto-continue to `/dashboard`); `page.tsx` reads `?k=`; `register/form.tsx` stashes credentials and pushes `/verify-email?k=<token>`.
- `autoSignInAfterVerification` flipped to `false` (the verifier requires it; the clicker device stays sessionless — cross-device flow). Updated the auth unit test and the `sign-up-verification` e2e cookie assertion (`toBeDefined` → `toBeUndefined`) accordingly; `change-email`/`password-reset` specs sign in explicitly already and needed only a comment fix.

### Misc
- `.husky/pre-commit` created (`pnpm lint-staged`) — `prepare: husky` existed but the hook file was missing.
- README prerequisite: pnpm 10 → pnpm 11 (matches `packageManager: pnpm@11.1.3`).

## Gate results
All run locally on this branch:
- `pnpm install` / `pnpm lint` / `pnpm typecheck` (11 tasks, now incl. `@repo/auth`) / `pnpm test` (11 tasks) / `pnpm build` / `pnpm fallow:dead` (no issues) / `pnpm format:check` — all green.
- Orchestrator: `./scripts/verify-all.sh --repo acme` → all verifiers passed (incl. `verify-verify-email-flow.sh`).

## Merge dependencies
- Orchestrator's `saas-actions-v6` branch carries the @v6 verifier expectation — land that orchestrator change with the fleet's workflow bumps.
- The e2e `auth-email` suite runs fully only in CI with `RESEND_API_KEY`; the `autoSignInAfterVerification` flip is covered by the updated spec there.