### PR TITLE
Add React Doctor CI

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -1,0 +1,26 @@
+name: React Doctor
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  statuses: write
+
+concurrency:
+  group: react-doctor-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  react-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: millionco/react-doctor@v2


### PR DESCRIPTION
Adds the React Doctor GitHub Action (millionco/react-doctor@v2): deterministic static analysis for React. On PRs it scans only changed files, posts one sticky summary comment plus inline comments on introduced issues; also runs on pushes to main. Single new workflow file, no other changes.