### PR TITLE
Improve: implement advisor plan (acme)

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,19 @@
+name: Typecheck
+on:
+  push:
+    branches: [main]
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck

--- a/apps/api/src/lib/users.test.ts
+++ b/apps/api/src/lib/users.test.ts
@@ -104,7 +104,6 @@ describe("updateUser", () => {
   });
 
   it("updates and returns user", async () => {
-    vi.mocked(prisma.user.findFirst).mockResolvedValue(null as never);
     vi.mocked(prisma.user.update).mockResolvedValue(mockUser as never);
 
     const result = await updateUser("user-1", { name: "New Name" });
@@ -112,25 +111,27 @@ describe("updateUser", () => {
     expect(result).toEqual(mockUser);
   });
 
-  it("throws AppError 400 when username is taken", async () => {
-    vi.mocked(prisma.user.findFirst).mockResolvedValue(mockUser as never);
+  it("throws AppError 409 USERNAME_TAKEN when a username change hits the unique constraint", async () => {
+    const conflict = prismaKnownError("P2002");
+    vi.mocked(prisma.user.update).mockRejectedValue(conflict);
 
     await expect(updateUser("user-2", { username: "testuser" })).rejects.toMatchObject({
       code: "USERNAME_TAKEN",
-      statusCode: 400,
+      statusCode: 409,
     });
   });
 
-  it("skips username check when username is not provided", async () => {
-    vi.mocked(prisma.user.update).mockResolvedValue(mockUser as never);
+  it("does NOT mislabel a non-username P2002 as USERNAME_TAKEN", async () => {
+    const conflict = prismaKnownError("P2002");
+    vi.mocked(prisma.user.update).mockRejectedValue(conflict);
 
-    await updateUser("user-1", { name: "Updated" });
-
-    expect(prisma.user.findFirst).not.toHaveBeenCalled();
+    // The update did not change the username, so the P2002 (e.g. email) must
+    // propagate untouched for the central handler's generic 409 DUPLICATE_ENTRY.
+    await expect(updateUser("user-1", { name: "X" })).rejects.toMatchObject({ code: "P2002" });
+    await expect(updateUser("user-1", { name: "X" })).rejects.not.toBeInstanceOf(AppError);
   });
 
   it("propagates P2025 to the central error handler", async () => {
-    vi.mocked(prisma.user.findFirst).mockResolvedValue(null as never);
     const notFound = prismaKnownError("P2025");
     vi.mocked(prisma.user.update).mockRejectedValue(notFound);
 
@@ -138,7 +139,6 @@ describe("updateUser", () => {
   });
 
   it("propagates generic database errors to the central error handler", async () => {
-    vi.mocked(prisma.user.findFirst).mockResolvedValue(null as never);
     const dbError = new Error("Connection refused");
     vi.mocked(prisma.user.update).mockRejectedValue(dbError);
 

--- a/apps/api/src/lib/users.ts
+++ b/apps/api/src/lib/users.ts
@@ -34,24 +34,27 @@ export const findUserByEmail = (email: string) =>
   });
 
 export const updateUser = async (id: string, data: Prisma.UserUpdateInput) => {
-  if (typeof data.username === "string") {
-    const existing = await prisma.user.findFirst({
-      where: {
-        NOT: { id },
-        username: data.username,
-      },
+  try {
+    return await prisma.user.update({
+      data,
+      select: userSelect,
+      where: { id },
     });
-
-    if (existing) {
-      throw new AppError("Username already taken", 400, true, "USERNAME_TAKEN");
+  } catch (error) {
+    // Only a username change can raise a username-uniqueness violation. Guarding
+    // on data.username keeps an unrelated P2002 (email, displayUsername) flowing
+    // to the central handler as a generic 409 instead of a misleading
+    // USERNAME_TAKEN.
+    if (
+      typeof data.username === "string" &&
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "P2002"
+    ) {
+      throw new AppError("Username already taken", 409, true, "USERNAME_TAKEN");
     }
+    throw error;
   }
-
-  return prisma.user.update({
-    data,
-    select: userSelect,
-    where: { id },
-  });
 };
 
 export const deleteUser = async (id: string) => {

--- a/apps/api/src/routes/v1/openapi.test.ts
+++ b/apps/api/src/routes/v1/openapi.test.ts
@@ -1,0 +1,39 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+  env: { NODE_ENV: "test" },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { getSession: vi.fn() } },
+}));
+
+import { v1UserRoutes } from "./users";
+
+describe("OpenAPI document — Error schema", () => {
+  it("declares the nested { error: { code, message } } shape", () => {
+    const app = new OpenAPIHono();
+    app.route("/api/v1/users", v1UserRoutes);
+    const doc = app.getOpenAPI31Document({
+      info: { title: "Acme API", version: "v1" },
+      openapi: "3.1.0",
+    });
+
+    const errorSchema = doc.components?.schemas?.Error;
+    expect(errorSchema).toBeDefined();
+    // nested: error is an object with code + message, NOT a top-level string
+    const inner = (errorSchema as { properties?: Record<string, unknown> }).properties?.error as
+      | { properties?: Record<string, unknown> }
+      | undefined;
+    expect(inner?.properties).toMatchObject({
+      code: expect.anything(),
+      message: expect.anything(),
+    });
+    // the old flat shape had a top-level string `error`; it must be gone
+    const topLevel = (errorSchema as { properties?: Record<string, unknown> }).properties?.error as
+      | { type?: string }
+      | undefined;
+    expect(topLevel?.type).not.toBe("string");
+  });
+});

--- a/apps/api/src/routes/v1/users.test.ts
+++ b/apps/api/src/routes/v1/users.test.ts
@@ -1,0 +1,135 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+  env: { NODE_ENV: "test" },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { getSession: vi.fn() } },
+}));
+
+vi.mock("@/lib/users", () => ({
+  deleteUser: vi.fn(),
+  findUserById: vi.fn(),
+  updateUser: vi.fn(),
+}));
+
+import { auth } from "@/lib/auth";
+import { deleteUser, findUserById, updateUser } from "@/lib/users";
+import { errorHandler } from "@/middleware/error-handler";
+
+import { v1UserRoutes } from "./users";
+
+const mockUser = {
+  createdAt: new Date("2024-01-01"),
+  displayName: "Test User",
+  email: "test@example.com",
+  emailVerified: true,
+  id: "user-1",
+  name: "Test",
+  updatedAt: new Date("2024-01-01"),
+  username: "testuser",
+};
+
+const serializedUser = {
+  ...mockUser,
+  createdAt: mockUser.createdAt.toISOString(),
+  updatedAt: mockUser.updatedAt.toISOString(),
+};
+
+const mockSession = (user: { email: string; id: string } | null) =>
+  vi.mocked(auth.api.getSession).mockResolvedValue((user ? { session: {}, user } : null) as never);
+
+// errorHandler reads c.get("log").error(...); seed a no-op logger so it resolves.
+const buildApp = () => {
+  const app = new OpenAPIHono();
+  app.use("*", (c, next) => {
+    c.set("log", { error: () => {}, info: () => {} } as never);
+    return next();
+  });
+  app.route("/api/v1/users", v1UserRoutes);
+  app.onError(errorHandler);
+  return app;
+};
+
+describe("v1 user routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET /me", () => {
+    it("returns the serialized user with ISO date strings", async () => {
+      mockSession({ email: "test@example.com", id: "user-1" });
+      vi.mocked(findUserById).mockResolvedValue(mockUser as never);
+
+      const res = await v1UserRoutes.request("/me", { headers: { Cookie: "session=x" } });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { data: typeof serializedUser };
+      expect(body).toEqual({ data: serializedUser });
+      expect(body.data.createdAt).toBe("2024-01-01T00:00:00.000Z");
+      expect(body.data.updatedAt).toBe("2024-01-01T00:00:00.000Z");
+    });
+
+    it("returns the nested 401 error shape when unauthenticated", async () => {
+      mockSession(null);
+
+      const app = buildApp();
+      const res = await app.request("/api/v1/users/me");
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({
+        error: { code: "HTTP_EXCEPTION", message: "Authentication required" },
+      });
+    });
+  });
+
+  describe("PATCH /me", () => {
+    it("returns the updated serialized user", async () => {
+      mockSession({ email: "test@example.com", id: "user-1" });
+      vi.mocked(updateUser).mockResolvedValue({ ...mockUser, name: "New Name" } as never);
+
+      const res = await v1UserRoutes.request("/me", {
+        body: JSON.stringify({ name: "New Name" }),
+        headers: { "Content-Type": "application/json", Cookie: "session=x" },
+        method: "PATCH",
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { data: { createdAt: string; name: string } };
+      expect(body.data.name).toBe("New Name");
+      expect(body.data.createdAt).toBe("2024-01-01T00:00:00.000Z");
+    });
+  });
+
+  describe("DELETE /me", () => {
+    it("returns 204 with no body", async () => {
+      mockSession({ email: "test@example.com", id: "user-1" });
+      vi.mocked(deleteUser).mockResolvedValue({ success: true } as never);
+
+      const res = await v1UserRoutes.request("/me", {
+        headers: { Cookie: "session=x" },
+        method: "DELETE",
+      });
+
+      expect(res.status).toBe(204);
+      expect(await res.text()).toBe("");
+    });
+  });
+
+  describe("GET /", () => {
+    it("returns the list envelope with data and meta", async () => {
+      mockSession({ email: "test@example.com", id: "user-1" });
+      vi.mocked(findUserById).mockResolvedValue(mockUser as never);
+
+      const res = await v1UserRoutes.request("/", { headers: { Cookie: "session=x" } });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        data: [serializedUser],
+        meta: { page: 1, total: 1, totalPages: 1 },
+      });
+    });
+  });
+});

--- a/apps/api/src/routes/v1/users.ts
+++ b/apps/api/src/routes/v1/users.ts
@@ -34,8 +34,12 @@ const updateUserSchema = z
 
 const errorSchema = z
   .object({
-    code: z.string().optional(),
-    error: z.string(),
+    error: z.object({
+      code: z.string(),
+      details: z.array(z.object({ field: z.string(), message: z.string() })).optional(),
+      message: z.string(),
+      stack: z.string().optional(),
+    }),
   })
   .openapi("Error");
 
@@ -92,11 +96,15 @@ const updateMeRoute = createRoute({
     },
     400: {
       content: { "application/json": { schema: errorSchema } },
-      description: "Validation error or username taken",
+      description: "Validation error",
     },
     401: {
       content: { "application/json": { schema: errorSchema } },
       description: "Unauthorized",
+    },
+    409: {
+      content: { "application/json": { schema: errorSchema } },
+      description: "Username already taken",
     },
   },
   summary: "Update current user",

--- a/apps/web/src/app/(auth)/register/form.tsx
+++ b/apps/web/src/app/(auth)/register/form.tsx
@@ -82,9 +82,6 @@ const RegisterForm = ({ from }: Props) => {
       setFormError(null);
       startTransition(async () => {
         try {
-          if (value.password !== value.confirmPassword) {
-            throw new Error("Passwords do not match");
-          }
           // Better Auth bakes callbackURL into the verification link, so the
           // email clicker lands back on the page that sent them to auth.
           const result = await authClient.signUp.email({

--- a/apps/web/src/app/(auth)/reset-password/form.tsx
+++ b/apps/web/src/app/(auth)/reset-password/form.tsx
@@ -82,9 +82,6 @@ const ResetPasswordForm = ({ token }: Props) => {
           if (!token) {
             throw new Error("Invalid reset token. Please request a new password reset.");
           }
-          if (value.password !== value.confirmPassword) {
-            throw new Error("Passwords do not match");
-          }
           const result = await authClient.resetPassword({
             newPassword: value.password,
             token,

--- a/apps/web/src/lib/form-schemas.test.ts
+++ b/apps/web/src/lib/form-schemas.test.ts
@@ -91,6 +91,32 @@ describe("registerSchema", () => {
     const result = registerSchema.safeParse({ ...validData, confirmPassword: "short" });
     expect(result.success).toBe(false);
   });
+
+  it("should reject when passwords do not match, with the issue on confirmPassword", () => {
+    const result = registerSchema.safeParse({
+      ...validData,
+      confirmPassword: "differentpassword",
+      password: "securepassword",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toContainEqual(
+        expect.objectContaining({
+          message: "Passwords do not match",
+          path: ["confirmPassword"],
+        }),
+      );
+    }
+  });
+
+  it("should accept when passwords match", () => {
+    const result = registerSchema.safeParse({
+      ...validData,
+      confirmPassword: "securepassword",
+      password: "securepassword",
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 describe("recoverSchema", () => {
@@ -144,6 +170,30 @@ describe("resetPasswordSchema", () => {
     const result = resetPasswordSchema.safeParse({
       confirmPassword: "123456789012",
       password: "123456789012",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject when passwords do not match, with the issue on confirmPassword", () => {
+    const result = resetPasswordSchema.safeParse({
+      confirmPassword: "newpassword34",
+      password: "newpassword12",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toContainEqual(
+        expect.objectContaining({
+          message: "Passwords do not match",
+          path: ["confirmPassword"],
+        }),
+      );
+    }
+  });
+
+  it("should accept when passwords match", () => {
+    const result = resetPasswordSchema.safeParse({
+      confirmPassword: "newpassword12",
+      password: "newpassword12",
     });
     expect(result.success).toBe(true);
   });

--- a/apps/web/src/lib/form-schemas.ts
+++ b/apps/web/src/lib/form-schemas.ts
@@ -5,18 +5,28 @@ export const loginSchema = z.object({
   password: z.string().min(12, "Password must be at least 12 characters"),
 });
 
-export const registerSchema = z.object({
-  confirmPassword: z.string().min(12, "Password must be at least 12 characters"),
-  email: z.email("Invalid email address"),
-  name: z.string().min(3, "Name must be at least 3 characters").max(32),
-  password: z.string().min(12, "Password must be at least 12 characters"),
-});
+export const registerSchema = z
+  .object({
+    confirmPassword: z.string().min(12, "Password must be at least 12 characters"),
+    email: z.email("Invalid email address"),
+    name: z.string().min(3, "Name must be at least 3 characters").max(32),
+    password: z.string().min(12, "Password must be at least 12 characters"),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
 
 export const recoverSchema = z.object({
   email: z.email("Enter a valid email address"),
 });
 
-export const resetPasswordSchema = z.object({
-  confirmPassword: z.string().min(12, "Password must be at least 12 characters"),
-  password: z.string().min(12, "Password must be at least 12 characters"),
-});
+export const resetPasswordSchema = z
+  .object({
+    confirmPassword: z.string().min(12, "Password must be at least 12 characters"),
+    password: z.string().min(12, "Password must be at least 12 characters"),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });


### PR DESCRIPTION
Implements every task from `plans/PLAN.md` (the revised consolidated advisor plan, planned at `ba473df`). Each task is one commit. `plans/PLAN.md` is intentionally excluded from the diff (operator-only tracking file).

## Per-task summary

### Task 1 — Fix OpenAPI error schema (flat → nested) + PATCH /me 409 doc — DONE
`fix(api): correct OpenAPI error schema + PATCH /me 409 doc; add OpenAPI regression test`
- Replaced the flat `{ code?, error }` `errorSchema` in `apps/api/src/routes/v1/users.ts` with the real nested `{ error: { code, message, details?, stack? } }` shape the server returns.
- Split `PATCH /me` docs: `400` "Validation error" + new `409` "Username already taken" (the doc half of Task 3's contract).
- Added `apps/api/src/routes/v1/openapi.test.ts` — builds the OpenAPI document and asserts `components.schemas.Error` is nested. Verified it FAILS on the old flat schema (proves it guards the shape).

### Task 2 — Route-level integration tests for /api/v1/users — DONE
`test(api): add route-level integration tests for /api/v1/users`
- New `apps/api/src/routes/v1/users.test.ts`: GET /me happy path + ISO date serialization; GET /me 401 nested-error contract; PATCH /me; DELETE /me 204; GET / list envelope (5 `it` cases, all assert parsed wire shape).
- The 401 test mounts the route on a minimal app with `errorHandler` + a seeded `log` to produce the documented nested `{ error: { code, message } }` body.

### Task 3 — Deterministic 409 for taken username — DONE
`fix(api): make username-taken deterministic 409, drop check-then-act race in updateUser`
- Rewrote `updateUser` (`apps/api/src/lib/users.ts`) to drop the `findFirst` pre-check and rely on the DB unique constraint; a `P2002` is translated to `AppError(409, USERNAME_TAKEN)` **only when `data.username` is a string**, so an unrelated unique violation (email/displayUsername) propagates untouched.
- Updated `updateUser` tests: 409 on username-change P2002; new test proving a non-username P2002 is NOT mislabeled (stays raw `P2002`, not an `AppError`); P2025/generic errors still propagate.
- Confirmed `username @unique` still in `schema.prisma:20` (STOP precondition held).

### Task 4 — Validate confirm-password in Zod, drop runtime throw — DONE
`fix(web): validate password match in schema via refine, drop runtime throw`
- Added `.refine(..., { path: ["confirmPassword"] })` to `registerSchema` and `resetPasswordSchema`.
- Removed the runtime `if (password !== confirmPassword) throw` blocks from the register and reset-password forms.
- Added 4 schema tests (mismatch rejected with issue on `confirmPassword`; match accepted) for both schemas.

### Task 5 — Typecheck CI gate (in-repo portion) — DONE (orchestrator follow-up deferred per instructions)
`ci: gate PRs on typecheck`
- Added `.github/workflows/typecheck.yml` mirroring `lint.yml`'s shape (`@v6` actions, `node-version: "24"`, `cache: pnpm`, `--frozen-lockfile`), running `pnpm typecheck`.
- Confirmed acme is type-clean (Step 0).

## Cross-repo follow-ups (NOT in this PR — out of scope per instructions)
Task 5 Step 3 requires editing the **orchestrator** repo (`~/dev/orchestrator`), skipped here:
- `scripts/verify-ci.sh`: add `"typecheck.yml"` to the saas `REQUIRED_WORKFLOWS` array, and refactor the hard-coded action-version loop to iterate `REQUIRED_WORKFLOWS` (skipping `e2e.yml`) so `typecheck.yml` inherits the `@v6` action checks.
- `standards.md`: list `typecheck.yml` in the CI section's saas workflow list.
- Then propagate `typecheck.yml` to the 5 downstream saas repos (Task 5 Step 4), each type-clean first.
- Also flag to operator: add the new Typecheck check to acme `main` branch-protection required checks.

Task 1 maintenance note: the same flat-vs-nested error-schema mismatch likely exists in the other saas repos that copied this route file — flag for fleet propagation (with the Task 3 409 runtime, propagate both halves together).

## Verification (from repo root; no `pnpm install` run)
- `pnpm typecheck` → 11/11 tasks successful, exit 0
- `pnpm lint` → exit 0 (oxlint clean)
- `pnpm test` → 11/11 tasks successful: api 59 passed (7 files), web 35 passed (2 files), @repo/auth 32, @repo/ui 10 — all green
- Baseline before changes was confirmed green first.

Based on `plans/PLAN.md`. No tasks skipped; no STOP conditions hit.
