### PR TITLE
ci: adopt pnpm/setup@v1 (single-step pnpm + runtime)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,12 +45,10 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: pnpm/setup@v1
         with:
-          node-version: "24"
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+          runtime: node@24
+          cache: true
       - run: pnpm db:generate
       - run: pnpm db:push
       - run: pnpm build --filter=web --filter=api --filter=landing

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -10,10 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: pnpm/setup@v1
         with:
-          node-version: "24"
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+          runtime: node@24
+          cache: true
       - run: pnpm fallow:dead

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,10 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: pnpm/setup@v1
         with:
-          node-version: "24"
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+          runtime: node@24
+          cache: true
       - run: pnpm run format:check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: pnpm/setup@v1
         with:
-          node-version: "24"
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+          runtime: node@24
+          cache: true
       - run: pnpm oxlint --format=github .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: pnpm/setup@v1
         with:
-          node-version: "24"
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+          runtime: node@24
+          cache: true
       - run: pnpm test

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -10,10 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: pnpm/setup@v1
         with:
-          node-version: "24"
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+          runtime: node@24
+          cache: true
       - run: pnpm typecheck


### PR DESCRIPTION
Replaces the `pnpm/action-setup@v6` + `actions/setup-node@v6` + manual `pnpm install --frozen-lockfile` trio with [`pnpm/setup@v1`](https://github.com/pnpm/setup) across every workflow.

```yaml
- uses: actions/checkout@v6
- uses: pnpm/setup@v1
  with:
    runtime: node@24
    cache: true
```

The action installs pnpm (version read from `package.json` `packageManager`), provisions the JS runtime, and runs `pnpm install` — frozen automatically under CI (`CI=true`). The `runtime:` pin is required (the action consults neither `engines` nor `devEngines`).

Source of truth for the fleet-wide rollout; orchestrator `verify-ci.sh` updated to enforce the new shape.