### PR TITLE
chore: trim slop comments (stop-slop sweep)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,27 +6,27 @@ import { Inter } from "next/font/google";
 import type { ReactNode } from "react";
 
 const inter = Inter({
-  display: "swap", // Improve font loading performance
+  display: "swap",
   subsets: ["latin"],
   variable: "--font-sans",
 });
 
 export const metadata: Metadata = {
   authors: [{ name: "Acme Team" }],
+  category: "technology",
   creator: "Acme",
   description:
     "A modern, secure authentication platform built with Better Auth and Next.js. Fast, reliable, and developer-friendly.",
+  icons: {
+    apple: "/apple-touch-icon.png",
+    icon: "/favicon.ico",
+    shortcut: "/favicon-16x16.png",
+  },
   keywords: ["authentication", "security", "next.js", "better-auth", "login", "registration"],
+  manifest: "/site.webmanifest",
   // Resolves Open Graph / Twitter card image URLs against this base.
   // Falls back to the canonical local web origin when WEB_APP_URL isn't set.
   metadataBase: new URL(process.env.WEB_APP_URL ?? "https://acme.web.localhost"),
-  publisher: "Acme",
-  title: {
-    default: "Acme | Secure Authentication Platform",
-    template: "%s | Acme",
-  },
-
-  // Open Graph
   openGraph: {
     description: "A modern, secure authentication platform built with Better Auth and Next.js.",
     images: [
@@ -42,16 +42,7 @@ export const metadata: Metadata = {
     title: "Acme - Secure Authentication Platform",
     type: "website",
   },
-
-  // Twitter
-  twitter: {
-    card: "summary_large_image",
-    description: "A modern, secure authentication platform built with Better Auth and Next.js.",
-    images: ["/twitter-image.png"],
-    title: "Acme - Secure Authentication Platform",
-  },
-
-  // Robots
+  publisher: "Acme",
   robots: {
     follow: true,
     googleBot: {
@@ -63,19 +54,16 @@ export const metadata: Metadata = {
     },
     index: true,
   },
-
-  // Icons
-  icons: {
-    apple: "/apple-touch-icon.png",
-    icon: "/favicon.ico",
-    shortcut: "/favicon-16x16.png",
+  title: {
+    default: "Acme | Secure Authentication Platform",
+    template: "%s | Acme",
   },
-
-  // Manifest
-  manifest: "/site.webmanifest",
-
-  // Other
-  category: "technology",
+  twitter: {
+    card: "summary_large_image",
+    description: "A modern, secure authentication platform built with Better Auth and Next.js.",
+    images: ["/twitter-image.png"],
+    title: "Acme - Secure Authentication Platform",
+  },
 };
 
 export const viewport: Viewport = {
@@ -93,7 +81,6 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
   return (
     <html className={inter.variable} lang="en">
       <head>
-        {/* Additional meta tags */}
         <meta content="telephone=no" name="format-detection" />
         <meta content="#000000" name="msapplication-TileColor" />
 

--- a/packages/transactional/src/index.ts
+++ b/packages/transactional/src/index.ts
@@ -1,13 +1,10 @@
-// Components
 export { AcmeLogo } from "./components/acme-logo";
 export { Button } from "./components/button";
 export { Card } from "./components/card";
 export { Divider } from "./components/divider";
 
-// Utilities
 export { sendEmail, sendBatchEmails, previewEmail } from "./lib/send-email";
 export type { MailerConfig, TransactionalEmail } from "./lib/senders";
 export { sendTransactionalEmail } from "./lib/senders";
 
-// Theme
 export { emailTheme, tailwindConfig } from "./styles/theme";


### PR DESCRIPTION
## What

Stop-slop sweep over hand-written source comments in acme (fleet source of truth). Comments only — no code behavior, identifiers, strings, or logic changed.

## Discipline applied

Per the repo's own rule "WHY comments only, never WHAT", deleted comments that restate code or act as decorative section labels, while keeping all genuine WHY context, directive/pragma comments, and useful JSDoc.

Removed:
- `apps/web/src/app/layout.tsx` — decorative `Metadata` section banners (`// Open Graph`, `// Twitter`, `// Robots`, `// Icons`, `// Manifest`, `// Other`), the `display: "swap" // Improve font loading performance` WHAT-comment, and a decorative `{/* Additional meta tags */}` JSX comment. Removing the banners exposed that they were masking a non-alphabetical key order, so the `metadata` keys are now sorted to satisfy `perfectionist/sort-objects` (object key order is semantically irrelevant for `Metadata` — no behavior change).
- `packages/transactional/src/index.ts` — decorative `// Components` / `// Utilities` / `// Theme` export-group banners.

Kept (deliberately): the large body of genuine WHY comments — open-redirect/auth reasoning, Better Auth cookie/verification contracts, Resend rate-limit backoff math, cross-origin session contracts, `@public` export markers, prisma datasource fallback rationale, and all `oxlint-disable`/`eslint-disable` directives.

## Counts

- Files reviewed: ~77 in-scope files containing comments (apps/, packages/, tests/, root configs)
- Files edited: 2
- Comments removed: 10 (9 banner/WHAT lines + 1 JSX banner)

## Verification

- `pnpm oxfmt` — clean
- `pnpm oxlint .` — 0 errors
- `pnpm typecheck` — clean