### PR TITLE
[React Doctor] fix 1 warning, score 84→94 (jsx-no-constructed-context-values)

### DIFF
--- a/packages/ui/src/components/field.tsx
+++ b/packages/ui/src/components/field.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ComponentProps, createContext, use, useId } from "react";
+import { type ComponentProps, createContext, use, useId, useMemo } from "react";
 
 import { cn } from "../lib/utils";
 
@@ -10,8 +10,9 @@ const useFieldContext = () => use(FieldContext);
 
 const Field = ({ className, ...props }: ComponentProps<"div">) => {
   const id = useId();
+  const fieldContextValue = useMemo(() => ({ id }), [id]);
   return (
-    <FieldContext value={{ id }}>
+    <FieldContext value={fieldContextValue}>
       <div className={cn("flex flex-col gap-2", className)} {...props} />
     </FieldContext>
   );


### PR DESCRIPTION
## Summary

Memoizes the `FieldContext` value in `packages/ui/src/components/field.tsx` so all `Field` consumers stop re-rendering on every parent render.

**Rule fixed:** `react-doctor/jsx-no-constructed-context-values` (P2 / Performance) — `packages/ui/src/components/field.tsx:14`

**Change:** Added `useMemo` import and wrapped `{ id }` in `useMemo(() => ({ id }), [id])` so the context object keeps a stable identity across renders. `useId()` already returns a stable value, so no behavior change — purely a reference-identity fix.

## Deferred (2 warnings, cross-file refactor)

- `react-doctor/only-export-components` — `packages/ui/src/components/button.tsx:56` — `buttonVariants` is imported by 3 external files via the `@repo/ui/components/button` path; splitting it into a sibling would touch 4+ files with no mechanical single-file recipe.
- `react-doctor/only-export-components` — `packages/ui/src/components/sonner.tsx:18` — `toast` is re-exported for 4 consumer files; moving it out touches 5+ files.

## Test plan

- [x] `pnpm typecheck` — passes (11 tasks, 0 errors)
- [x] `pnpm lint` — passes (oxlint clean)
- [x] `pnpm format` — passes (oxfmt, 191 files)
- [x] React Doctor re-scan: 2 warnings remaining (both deferred), score 84→94