### PR TITLE
feat(ui): refresh Card to base-nova design

### DIFF
--- a/packages/ui/src/components/card.tsx
+++ b/packages/ui/src/components/card.tsx
@@ -2,13 +2,18 @@ import type { ComponentProps } from "react";
 
 import { cn } from "../lib/utils";
 
-const Card = ({ className, ...props }: ComponentProps<"div">) => {
+const Card = ({
+  className,
+  size = "default",
+  ...props
+}: ComponentProps<"div"> & { size?: "default" | "sm" }) => {
   return (
     <div
       className={cn(
-        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
+        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground ring-1 ring-foreground/10 [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
         className,
       )}
+      data-size={size}
       data-slot="card"
       {...props}
     />
@@ -19,7 +24,7 @@ const CardHeader = ({ className, ...props }: ComponentProps<"div">) => {
   return (
     <div
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
         className,
       )}
       data-slot="card-header"
@@ -30,7 +35,14 @@ const CardHeader = ({ className, ...props }: ComponentProps<"div">) => {
 
 const CardTitle = ({ children, className, ...props }: ComponentProps<"h2">) => {
   return (
-    <h2 className={cn("leading-none font-semibold", className)} data-slot="card-title" {...props}>
+    <h2
+      className={cn(
+        "text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className,
+      )}
+      data-slot="card-title"
+      {...props}
+    >
       {children}
     </h2>
   );
@@ -57,13 +69,18 @@ const CardAction = ({ className, ...props }: ComponentProps<"div">) => {
 };
 
 const CardContent = ({ className, ...props }: ComponentProps<"div">) => {
-  return <div className={cn("px-6", className)} data-slot="card-content" {...props} />;
+  return (
+    <div className={cn("px-(--card-spacing)", className)} data-slot="card-content" {...props} />
+  );
 };
 
 const CardFooter = ({ className, ...props }: ComponentProps<"div">) => {
   return (
     <div
-      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-(--card-spacing)",
+        className,
+      )}
       data-slot="card-footer"
       {...props}
     />


### PR DESCRIPTION
## What

Refreshes `@repo/ui` `Card` to the current shadcn **base-nova** registry design — the one genuine upstream change found in a diff & cherry-pick pass over all 5 components (`button`, `card`, `input`, `field`, `sonner`). The other four are already aligned with, or deliberately ahead of, the registry (e.g. `button` keeps its perf-narrowed `transition-[…]` over upstream's `transition-all`; `input` keeps its custom `startIcon`/`endIcon`; `field` is a bespoke TanStack wrapper).

## Card changes

- `ring-1 ring-foreground/10` instead of `border` + `shadow-sm`
- new `size` prop (`"default" | "sm"`) driving a `--card-spacing` variable
- `overflow-hidden` + automatic image corner-rounding (`*:[img:first-child]:rounded-t-xl`)
- muted footer treatment (`border-t bg-muted/50`) and `has-data-[slot=card-footer]:pb-0`

## Cherry-pick decisions (preserved over the raw registry)

- **`CardTitle` stays `<h2>`** and **`CardDescription` stays `<p>`** — upstream regressed both to `<div>`; acme's semantic elements are kept for a11y.
- Dropped the undefined `cn-font-heading` utility from `CardTitle`.

## Verification

- orchestrator `verify-theme`, `verify-ui`, `verify-base-styles`, `verify-naming` (acme) — all pass
- `@repo/ui` `oxlint` + `tsc --noEmit` — clean (lint caught a `heading-has-content` issue on the new `<h2>`; fixed by rendering explicit children)

Template-first; propagation to the other 6 saas `@repo/ui` packages follows in sibling PRs.