### PR TITLE
perf: react-doctor triage — unblock React Compiler memoization on auth forms

### DIFF
--- a/apps/web/src/app/(auth)/login/form.tsx
+++ b/apps/web/src/app/(auth)/login/form.tsx
@@ -120,7 +120,12 @@ const LoginForm = ({ from }: Props) => {
               setShowUnverifiedNotice(true);
               return;
             }
-            throw new Error(result.error.message ?? "Invalid credentials");
+            // Inline instead of throw-to-catch: React Compiler can't memoize
+            // components with a ThrowStatement inside try/catch yet.
+            const message = result.error.message ?? "Invalid credentials";
+            setFormError(message);
+            toast.error(message);
+            return;
           }
           push(from);
           refresh();

--- a/apps/web/src/app/(auth)/recover/form.tsx
+++ b/apps/web/src/app/(auth)/recover/form.tsx
@@ -76,7 +76,12 @@ const RecoverForm = () => {
             redirectTo: `${window.location.origin}/reset-password`,
           });
           if (result.error) {
-            throw new Error(result.error.message ?? "Failed to send password reset email");
+            // Inline instead of throw-to-catch: React Compiler can't memoize
+            // components with a ThrowStatement inside try/catch yet.
+            const message = result.error.message ?? "Failed to send password reset email";
+            setFormError(message);
+            toast.error(message);
+            return;
           }
           setSubmittedEmail(value.email);
         } catch (error) {

--- a/apps/web/src/app/(auth)/register/form.tsx
+++ b/apps/web/src/app/(auth)/register/form.tsx
@@ -91,7 +91,12 @@ const RegisterForm = ({ from }: Props) => {
             password: value.password,
           });
           if (result.error) {
-            throw new Error(result.error.message ?? "Failed to register");
+            // Inline instead of throw-to-catch: React Compiler can't memoize
+            // components with a ThrowStatement inside try/catch yet.
+            const message = result.error.message ?? "Failed to register";
+            setFormError(message);
+            toast.error(message);
+            return;
           }
           // No token means requireEmailVerification suppressed auto-sign-in (or enumeration prevention
           // returned synthetic success); both paths show the same inline "check your email" state.

--- a/apps/web/src/app/(auth)/reset-password/form.tsx
+++ b/apps/web/src/app/(auth)/reset-password/form.tsx
@@ -78,16 +78,24 @@ const ResetPasswordForm = ({ token }: Props) => {
     onSubmit: ({ value }) => {
       setFormError(null);
       startTransition(async () => {
+        // Inline error paths instead of throw-to-catch: React Compiler can't
+        // memoize components with a ThrowStatement inside try/catch yet.
+        if (!token) {
+          const message = "Invalid reset token. Please request a new password reset.";
+          setFormError(message);
+          toast.error(message);
+          return;
+        }
         try {
-          if (!token) {
-            throw new Error("Invalid reset token. Please request a new password reset.");
-          }
           const result = await authClient.resetPassword({
             newPassword: value.password,
             token,
           });
           if (result.error) {
-            throw new Error(result.error.message ?? "Failed to reset password");
+            const message = result.error.message ?? "Failed to reset password";
+            setFormError(message);
+            toast.error(message);
+            return;
           }
           push("/login?message=password-reset-success");
         } catch (error) {


### PR DESCRIPTION
React Doctor 0.6.3 full-scan triage on the acme template (post-Next 16.3 rollout). Score **49 → 86** (Critical → Great): all 5 errors fixed, 8 warnings triaged as false positives or out of scope for this PR.

## Fixed

All five errors were the same React Compiler bailout — `Todo: (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch` — meaning the compiler skipped automatic memoization of the entire component. Replaced each `throw new Error(…)` inside the submit handlers' `try` with the identical inline error handling the `catch` performed (`setFormError` + `toast.error`), then `return`. The `try/catch` stays to guard network failures from the `await`. Messages, state transitions, and toasts are byte-for-byte identical; each form remains self-contained (no shared helpers).

| Severity | Rule | File | Fix |
|---|---|---|---|
| error | `react-hooks-js/todo` | `apps/web/src/app/(auth)/login/form.tsx:123` | inline error path, drop `throw` |
| error | `react-hooks-js/todo` | `apps/web/src/app/(auth)/recover/form.tsx:79` | inline error path, drop `throw` |
| error | `react-hooks-js/todo` | `apps/web/src/app/(auth)/register/form.tsx:94` | inline error path, drop `throw` |
| error | `react-hooks-js/todo` | `apps/web/src/app/(auth)/reset-password/form.tsx:83` | hoist token guard above `try`, inline error path |
| error | `react-hooks-js/todo` | `apps/web/src/app/(auth)/reset-password/form.tsx:90` | inline error path, drop `throw` |

## Skipped (with reasons)

| Severity | Rule | Target | Reason |
|---|---|---|---|
| warning | `deslop/unused-export` | `packages/transactional/src/emails/{welcome,change-email,password-reset,sign-up-attempt}.tsx` default exports | False positive — react-email's preview server (`pnpm preview` → `email dev --dir ./src`) renders templates via their default export; a consumer the scanner can't see |
| warning | `deslop/unused-dev-dependency` | `better-auth` in `packages/observability` | False positive — declared optional `peerDependency`; the devDep satisfies it locally so `tsc` can resolve `evlog/better-auth` types. Also a package.json/lockfile change, reserved for `chore/deps-latest-2026-07` |
| warning | `deslop/unused-dev-dependency` | `@react-email/ui` in `packages/transactional` | Dependency change — out of scope for this PR to avoid conflicting with the open `chore/deps-latest-2026-07`; worth confirming usage there |
| warning | `react-doctor/only-export-components` | `packages/ui/src/components/button.tsx` (`buttonVariants`), `sonner.tsx` (`toast`) | Deferred — splitting these exports changes `@repo/ui`'s public import surface on the fleet template (both are imported by apps; the shapes are pinned by the orchestrator's `verify-shared-ui`/`verify-button-native-prop`). Dev-only Fast Refresh benefit doesn't justify a fleet-wide API change |

## Beyond react-doctor

Swept the orchestrator verifier domains against this branch (theme tokens, pointless async Server Components, TanStack `field` in hook deps, raw `console.*`/evlog, bundle-heavy static imports, e2e/auth conventions): **all verifiers pass, nothing to fix** — the June 0.5.8 triage plus fleet standards are holding.

## Verification

- `pnpm lint` / `pnpm format:check` / `pnpm typecheck` (11 tasks) / `pnpm test` (11 tasks) / `pnpm build` (6 tasks) — all green
- `npx react-doctor@latest`: 0 errors, score 86, remaining 8 warnings all triaged above
- Orchestrator `verify-all.sh --repo acme` run against this branch: all verifiers pass
