### PR TITLE
fix(web): survive missing BETTER_AUTH_SECRET in proxy session lookup

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -8,6 +8,24 @@ const protectedRoutes = ["/dashboard", "/profile", "/settings"];
 
 const authRoutes = ["/login", "/register", "/recover", "/reset-password"];
 
+const getSessionOrNull = async (request: NextRequest) => {
+  try {
+    // try/catch instead of a promise-chain .catch(): getAuth() throws
+    // synchronously when BETTER_AUTH_SECRET is absent (e.g. preview deploys),
+    // which a .catch() attached after the call can never intercept.
+    return await getAuth().api.getSession({ headers: request.headers });
+  } catch (error) {
+    // Auth service failure (DB down, misconfiguration, etc.) — log so outages
+    // are observable, then treat as unauthenticated to keep the pipeline moving.
+    log.error({
+      error: error instanceof Error ? error.message : String(error),
+      message: "proxy: getSession failed — treating as unauthenticated",
+      pathname: request.nextUrl.pathname,
+    });
+    return null;
+  }
+};
+
 export const proxy = async (request: NextRequest) => {
   const pathname = request.nextUrl.pathname;
 
@@ -19,20 +37,7 @@ export const proxy = async (request: NextRequest) => {
     return NextResponse.next();
   }
 
-  const session = await getAuth()
-    .api.getSession({
-      headers: request.headers,
-    })
-    .catch((error) => {
-      // Auth service failure (DB down, misconfiguration, etc.) — log so outages
-      // are observable, then treat as unauthenticated to keep the pipeline moving.
-      log.error({
-        error,
-        message: "proxy: getSession failed — treating as unauthenticated",
-        pathname,
-      });
-      return null;
-    });
+  const session = await getSessionOrNull(request);
 
   if (isProtectedRoute && !session) {
     const url = new URL("/login", request.url);


### PR DESCRIPTION
## Summary

Propagates unlockers-io/easeia-monorepo#136 to the template.

`getAuth()` throws **synchronously** when `BETTER_AUTH_SECRET` is missing, escaping the promise-chain `.catch()` in `apps/web/src/proxy.ts` and 500ing every matched route (all pre-auth pages) on env-less deployments — e.g. Vercel previews, which run without the secret by policy.

## Fix

- Wrap the session lookup in a `getSessionOrNull(request)` helper with try/catch (same shape as easeia#136).
- Failures are logged and treated as unauthenticated; `getAuth()`'s fail-fast contract is untouched.
- Error is stringified in the log payload so it no longer serializes as `{}`.

## Verification

Local repro with a production build and all `BETTER_AUTH_*` env unset:

- before: `GET /login` → **500** ("BETTER_AUTH_SECRET environment variable is required")
- after: `GET /login` → **200**, `GET /dashboard` → **307** to `/login?from=%2Fdashboard`, failure logged

`lint`, `format:check`, `typecheck`, `build`, `test` all green.